### PR TITLE
:recycle: Use slice of pointers & improve comments

### DIFF
--- a/model/BlockRange.go
+++ b/model/BlockRange.go
@@ -13,29 +13,29 @@ type BlockRange struct {
 }
 
 // ID returns the ID of the entry
-func (m BlockRange) ID() int {
+func (m *BlockRange) ID() int {
 	return m.BlockRangeID
 }
 
-func (m BlockRange) tableName() string {
+func (m *BlockRange) tableName() string {
 	return "BlockRange"
 }
 
-func (m BlockRange) idName() string {
+func (m *BlockRange) idName() string {
 	return "BlockRangeId"
 }
 
-func (m BlockRange) scanRow(rows *sql.Rows) (model, error) {
+func (m *BlockRange) scanRow(rows *sql.Rows) (model, error) {
 	err := rows.Scan(&m.BlockRangeID, &m.BlockType, &m.Identifier, &m.StartToken, &m.EndToken, &m.UserMarkID)
 	return m, err
 }
 
 // makeSlice converts a slice of the generice interface model
-func (BlockRange) makeSlice(mdl []model) []BlockRange {
-	result := make([]BlockRange, len(mdl))
+func (BlockRange) makeSlice(mdl []*model) []*BlockRange {
+	result := make([]*BlockRange, len(mdl))
 	for i := range mdl {
 		if mdl[i] != nil {
-			result[i] = mdl[i].(BlockRange)
+			result[i] = (*mdl[i]).(*BlockRange)
 		}
 	}
 	return result

--- a/model/Bookmark.go
+++ b/model/Bookmark.go
@@ -15,30 +15,30 @@ type Bookmark struct {
 }
 
 // ID returns the ID of the entry
-func (m Bookmark) ID() int {
+func (m *Bookmark) ID() int {
 	return m.BookmarkID
 }
 
-func (m Bookmark) tableName() string {
+func (m *Bookmark) tableName() string {
 	return "Bookmark"
 }
 
-func (m Bookmark) idName() string {
+func (m *Bookmark) idName() string {
 	return "BookmarkId"
 }
 
-func (m Bookmark) scanRow(rows *sql.Rows) (model, error) {
+func (m *Bookmark) scanRow(rows *sql.Rows) (model, error) {
 	err := rows.Scan(&m.BookmarkID, &m.LocationID, &m.PublicationLocationID, &m.Slot, &m.Title,
 		&m.Snippet, &m.BlockType, &m.BlockIdentifier)
 	return m, err
 }
 
 // makeSlice converts a slice of the generice interface model
-func (Bookmark) makeSlice(mdl []model) []Bookmark {
-	result := make([]Bookmark, len(mdl))
+func (Bookmark) makeSlice(mdl []*model) []*Bookmark {
+	result := make([]*Bookmark, len(mdl))
 	for i := range mdl {
 		if mdl[i] != nil {
-			result[i] = mdl[i].(Bookmark)
+			result[i] = (*mdl[i]).(*Bookmark)
 		}
 	}
 	return result

--- a/model/Database_test.go
+++ b/model/Database_test.go
@@ -26,14 +26,14 @@ func Test_getSliceCapacity(t *testing.T) {
 	rows := mock.NewRows([]string{"TagId"}).AddRow(3)
 	mock.ExpectQuery("SELECT TagId FROM Tag ORDER BY TagId DESC LIMIT 1").WillReturnRows(rows)
 
-	res, err := getSliceCapacity(db, Tag{})
+	res, err := getSliceCapacity(db, &Tag{})
 	assert.NoError(t, err)
 	assert.Equal(t, 4, res)
 
 	// Test with empty DB
 	rows = mock.NewRows([]string{"TagId"})
 	mock.ExpectQuery("SELECT TagId FROM Tag ORDER BY TagId DESC LIMIT 1").WillReturnRows(rows)
-	res, err = getSliceCapacity(db, Tag{})
+	res, err = getSliceCapacity(db, &Tag{})
 	assert.NoError(t, err)
 	assert.Equal(t, 1, res)
 }
@@ -49,37 +49,37 @@ func Test_fetchFromSQLite(t *testing.T) {
 	blockRange, err := fetchFromSQLite(sqlite, &BlockRange{})
 	assert.NoError(t, err)
 	assert.Len(t, blockRange, 5)
-	assert.Contains(t, blockRange, BlockRange{3, 2, 13, sql.NullInt32{Int32: 0, Valid: true}, sql.NullInt32{Int32: 14, Valid: true}, 3})
+	assert.Equal(t, &BlockRange{3, 2, 13, sql.NullInt32{Int32: 0, Valid: true}, sql.NullInt32{Int32: 14, Valid: true}, 3}, (*blockRange[3]))
 
 	bookmark, err := fetchFromSQLite(sqlite, &Bookmark{})
 	assert.NoError(t, err)
 	assert.Len(t, bookmark, 3)
-	assert.Contains(t, bookmark, Bookmark{2, 3, 7, 4, "Philippians 4", sql.NullString{String: "12 I know how to be low on provisions and how to have an abundance. In everything and in all circumstances I have learned the secret of both how to be full and how to hunger, both how to have an abundance and how to do without. ", Valid: true}, 0, sql.NullInt32{}})
+	assert.Equal(t, &Bookmark{2, 3, 7, 4, "Philippians 4", sql.NullString{String: "12 I know how to be low on provisions and how to have an abundance. In everything and in all circumstances I have learned the secret of both how to be full and how to hunger, both how to have an abundance and how to do without. ", Valid: true}, 0, sql.NullInt32{}}, (*bookmark[2]))
 
 	location, err := fetchFromSQLite(sqlite, &Location{})
 	assert.NoError(t, err)
 	assert.Len(t, location, 8)
-	assert.Contains(t, location, Location{4, sql.NullInt32{Int32: 66, Valid: true}, sql.NullInt32{Int32: 21, Valid: true}, sql.NullInt32{}, sql.NullInt32{}, 0, sql.NullString{String: "nwtsty", Valid: true}, 2, 0, sql.NullString{String: "Offenbarung 21", Valid: true}})
+	assert.Equal(t, &Location{4, sql.NullInt32{Int32: 66, Valid: true}, sql.NullInt32{Int32: 21, Valid: true}, sql.NullInt32{}, sql.NullInt32{}, 0, sql.NullString{String: "nwtsty", Valid: true}, 2, 0, sql.NullString{String: "Offenbarung 21", Valid: true}}, (*location[4]))
 
 	note, err := fetchFromSQLite(sqlite, &Note{})
 	assert.NoError(t, err)
 	assert.Len(t, note, 3)
-	assert.Contains(t, note, Note{2, "F75A18EE-FC17-4E0B-ABB6-CC16DABE9610", sql.NullInt32{Int32: 3, Valid: true}, sql.NullInt32{Int32: 3, Valid: true}, sql.NullString{String: "For all things I have the strength through the one who gives me power.", Valid: true}, sql.NullString{String: "", Valid: true}, "2020-04-14T18:42:14+00:00", 2, sql.NullInt32{Int32: 13, Valid: true}})
+	assert.Equal(t, &Note{2, "F75A18EE-FC17-4E0B-ABB6-CC16DABE9610", sql.NullInt32{Int32: 3, Valid: true}, sql.NullInt32{Int32: 3, Valid: true}, sql.NullString{String: "For all things I have the strength through the one who gives me power.", Valid: true}, sql.NullString{String: "", Valid: true}, "2020-04-14T18:42:14+00:00", 2, sql.NullInt32{Int32: 13, Valid: true}}, (*note[2]))
 
 	tag, err := fetchFromSQLite(sqlite, &Tag{})
 	assert.NoError(t, err)
 	assert.Len(t, tag, 3)
-	assert.Contains(t, tag, Tag{2, 1, "Strengthening", sql.NullString{}})
+	assert.Equal(t, &Tag{2, 1, "Strengthening", sql.NullString{}}, (*tag[2]))
 
 	tagMap, err := fetchFromSQLite(sqlite, &TagMap{})
 	assert.NoError(t, err)
 	assert.Len(t, tagMap, 3)
-	assert.Contains(t, tagMap, TagMap{2, sql.NullInt32{Int32: 0, Valid: false}, sql.NullInt32{Int32: 0, Valid: false}, sql.NullInt32{Int32: 2, Valid: true}, 2, 1})
+	assert.Equal(t, &TagMap{2, sql.NullInt32{Int32: 0, Valid: false}, sql.NullInt32{Int32: 0, Valid: false}, sql.NullInt32{Int32: 2, Valid: true}, 2, 1}, (*tagMap[2]))
 
 	userMark, err := fetchFromSQLite(sqlite, &UserMark{})
 	assert.NoError(t, err)
 	assert.Len(t, userMark, 5)
-	assert.Contains(t, userMark, UserMark{2, 1, 2, 0, "2C5E7B4A-4997-4EDA-9CFF-38A7599C487B", 1})
+	assert.Equal(t, &UserMark{2, 1, 2, 0, "2C5E7B4A-4997-4EDA-9CFF-38A7599C487B", 1}, (*userMark[2]))
 }
 
 func TestDatabase_importSQLite(t *testing.T) {
@@ -88,8 +88,8 @@ func TestDatabase_importSQLite(t *testing.T) {
 	path := filepath.Join("testdata", "user_data.db")
 	assert.NoError(t, db.importSQLite(path))
 
-	// As we already test the correct in Test_fetchFromSQLite,
-	// it should be sufficient to just double-check the size of the slices
+	// As we already test the correctness in Test_fetchFromSQLite,
+	// it should be sufficient to just double-check the size of the slices.
 	assert.Len(t, db.BlockRange, 5)
 	assert.Len(t, db.Bookmark, 3)
 	assert.Len(t, db.Location, 8)
@@ -105,8 +105,8 @@ func TestDatabase_ImportJWLBackup(t *testing.T) {
 	path := filepath.Join("testdata", "backup.jwlibrary")
 	assert.NoError(t, db.ImportJWLBackup(path))
 
-	// As we already test the correct in Test_fetchFromSQLite,
-	// it should be sufficient to just double-check the size of the slices
+	// As we already test the correctness in Test_fetchFromSQLite,
+	// it should be sufficient to just double-check the size of the slices.
 	assert.Len(t, db.BlockRange, 5)
 	assert.Len(t, db.Bookmark, 3)
 	assert.Len(t, db.Location, 8)
@@ -123,7 +123,7 @@ func TestDatabase_ExportJWLBackup(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.RemoveAll(testFolder)
 
-	// Test of import->export->import tweakes Data in wrong way
+	// Test if import->export->import tweakes Data in wrong way
 	db := Database{}
 
 	path := filepath.Join("testdata", "backup.jwlibrary")
@@ -136,25 +136,25 @@ func TestDatabase_ExportJWLBackup(t *testing.T) {
 	assert.NoError(t, db.ImportJWLBackup(newPath))
 
 	assert.Len(t, db.BlockRange, 5)
-	assert.Contains(t, db.BlockRange, BlockRange{3, 2, 13, sql.NullInt32{Int32: 0, Valid: true}, sql.NullInt32{Int32: 14, Valid: true}, 3})
+	assert.Equal(t, &BlockRange{3, 2, 13, sql.NullInt32{Int32: 0, Valid: true}, sql.NullInt32{Int32: 14, Valid: true}, 3}, db.BlockRange[3])
 
 	assert.Len(t, db.Bookmark, 3)
-	assert.Contains(t, db.Bookmark, Bookmark{2, 3, 7, 4, "Philippians 4", sql.NullString{String: "12 I know how to be low on provisions and how to have an abundance. In everything and in all circumstances I have learned the secret of both how to be full and how to hunger, both how to have an abundance and how to do without. ", Valid: true}, 0, sql.NullInt32{}})
+	assert.Equal(t, &Bookmark{2, 3, 7, 4, "Philippians 4", sql.NullString{String: "12 I know how to be low on provisions and how to have an abundance. In everything and in all circumstances I have learned the secret of both how to be full and how to hunger, both how to have an abundance and how to do without. ", Valid: true}, 0, sql.NullInt32{}}, db.Bookmark[2])
 
 	assert.Len(t, db.Location, 8)
-	assert.Contains(t, db.Location, Location{4, sql.NullInt32{Int32: 66, Valid: true}, sql.NullInt32{Int32: 21, Valid: true}, sql.NullInt32{}, sql.NullInt32{}, 0, sql.NullString{String: "nwtsty", Valid: true}, 2, 0, sql.NullString{String: "Offenbarung 21", Valid: true}})
+	assert.Equal(t, &Location{4, sql.NullInt32{Int32: 66, Valid: true}, sql.NullInt32{Int32: 21, Valid: true}, sql.NullInt32{}, sql.NullInt32{}, 0, sql.NullString{String: "nwtsty", Valid: true}, 2, 0, sql.NullString{String: "Offenbarung 21", Valid: true}}, db.Location[4])
 
 	assert.Len(t, db.Note, 3)
-	assert.Contains(t, db.Note, Note{2, "F75A18EE-FC17-4E0B-ABB6-CC16DABE9610", sql.NullInt32{Int32: 3, Valid: true}, sql.NullInt32{Int32: 3, Valid: true}, sql.NullString{String: "For all things I have the strength through the one who gives me power.", Valid: true}, sql.NullString{String: "", Valid: true}, "2020-04-14T18:42:14+00:00", 2, sql.NullInt32{Int32: 13, Valid: true}})
+	assert.Equal(t, &Note{2, "F75A18EE-FC17-4E0B-ABB6-CC16DABE9610", sql.NullInt32{Int32: 3, Valid: true}, sql.NullInt32{Int32: 3, Valid: true}, sql.NullString{String: "For all things I have the strength through the one who gives me power.", Valid: true}, sql.NullString{String: "", Valid: true}, "2020-04-14T18:42:14+00:00", 2, sql.NullInt32{Int32: 13, Valid: true}}, db.Note[2])
 
 	assert.Len(t, db.Tag, 3)
-	assert.Contains(t, db.Tag, Tag{2, 1, "Strengthening", sql.NullString{}})
+	assert.Equal(t, &Tag{2, 1, "Strengthening", sql.NullString{}}, db.Tag[2])
 
 	assert.Len(t, db.TagMap, 3)
-	assert.Contains(t, db.TagMap, TagMap{2, sql.NullInt32{Int32: 0, Valid: false}, sql.NullInt32{Int32: 0, Valid: false}, sql.NullInt32{Int32: 2, Valid: true}, 2, 1})
+	assert.Equal(t, &TagMap{2, sql.NullInt32{Int32: 0, Valid: false}, sql.NullInt32{Int32: 0, Valid: false}, sql.NullInt32{Int32: 2, Valid: true}, 2, 1}, db.TagMap[2])
 
 	assert.Len(t, db.UserMark, 5)
-	assert.Contains(t, db.UserMark, UserMark{2, 1, 2, 0, "2C5E7B4A-4997-4EDA-9CFF-38A7599C487B", 1})
+	assert.Equal(t, &UserMark{2, 1, 2, 0, "2C5E7B4A-4997-4EDA-9CFF-38A7599C487B", 1}, db.UserMark[2])
 }
 
 func Test_createEmptySQLiteDB(t *testing.T) {
@@ -189,13 +189,13 @@ func TestDatabase_saveToNewSQLite(t *testing.T) {
 	defer os.RemoveAll(tmpFolder)
 
 	db := Database{
-		BlockRange: []BlockRange{{3, 2, 13, sql.NullInt32{Int32: 0, Valid: true}, sql.NullInt32{Int32: 14, Valid: true}, 3}},
-		Bookmark:   []Bookmark{{2, 3, 7, 4, "Philippians 4", sql.NullString{String: "12 I know how to be low on provisions and how to have an abundance. In everything and in all circumstances I have learned the secret of both how to be full and how to hunger, both how to have an abundance and how to do without. ", Valid: true}, 0, sql.NullInt32{}}},
-		Location:   []Location{{4, sql.NullInt32{Int32: 66, Valid: true}, sql.NullInt32{Int32: 21, Valid: true}, sql.NullInt32{}, sql.NullInt32{}, 0, sql.NullString{String: "nwtsty", Valid: true}, 2, 0, sql.NullString{String: "Offenbarung 21", Valid: true}}},
-		Note:       []Note{{2, "F75A18EE-FC17-4E0B-ABB6-CC16DABE9610", sql.NullInt32{Int32: 3, Valid: true}, sql.NullInt32{Int32: 3, Valid: true}, sql.NullString{String: "For all things I have the strength through the one who gives me power.", Valid: true}, sql.NullString{String: "!", Valid: true}, "2020-04-14T18:42:14+00:00", 2, sql.NullInt32{Int32: 13, Valid: true}}},
-		Tag:        []Tag{{2, 1, "Strengthening", sql.NullString{}}},
-		TagMap:     []TagMap{{2, sql.NullInt32{Int32: 0, Valid: false}, sql.NullInt32{Int32: 0, Valid: false}, sql.NullInt32{Int32: 2, Valid: true}, 2, 1}},
-		UserMark:   []UserMark{{2, 1, 2, 0, "2C5E7B4A-4997-4EDA-9CFF-38A7599C487B", 1}},
+		BlockRange: []*BlockRange{{3, 2, 13, sql.NullInt32{Int32: 0, Valid: true}, sql.NullInt32{Int32: 14, Valid: true}, 3}},
+		Bookmark:   []*Bookmark{{2, 3, 7, 4, "Philippians 4", sql.NullString{String: "12 I know how to be low on provisions and how to have an abundance. In everything and in all circumstances I have learned the secret of both how to be full and how to hunger, both how to have an abundance and how to do without. ", Valid: true}, 0, sql.NullInt32{}}},
+		Location:   []*Location{{4, sql.NullInt32{Int32: 66, Valid: true}, sql.NullInt32{Int32: 21, Valid: true}, sql.NullInt32{}, sql.NullInt32{}, 0, sql.NullString{String: "nwtsty", Valid: true}, 2, 0, sql.NullString{String: "Offenbarung 21", Valid: true}}},
+		Note:       []*Note{{2, "F75A18EE-FC17-4E0B-ABB6-CC16DABE9610", sql.NullInt32{Int32: 3, Valid: true}, sql.NullInt32{Int32: 3, Valid: true}, sql.NullString{String: "For all things I have the strength through the one who gives me power.", Valid: true}, sql.NullString{String: "!", Valid: true}, "2020-04-14T18:42:14+00:00", 2, sql.NullInt32{Int32: 13, Valid: true}}},
+		Tag:        []*Tag{{2, 1, "Strengthening", sql.NullString{}}},
+		TagMap:     []*TagMap{{2, sql.NullInt32{Int32: 0, Valid: false}, sql.NullInt32{Int32: 0, Valid: false}, sql.NullInt32{Int32: 2, Valid: true}, 2, 1}},
+		UserMark:   []*UserMark{{2, 1, 2, 0, "2C5E7B4A-4997-4EDA-9CFF-38A7599C487B", 1}},
 	}
 	path := filepath.Join(tmpFolder, "user_data.db")
 	err = db.saveToNewSQLite(path)

--- a/model/Location.go
+++ b/model/Location.go
@@ -19,30 +19,30 @@ type Location struct {
 }
 
 // ID returns the ID of the entry
-func (m Location) ID() int {
+func (m *Location) ID() int {
 	return m.LocationID
 }
 
-func (m Location) tableName() string {
+func (m *Location) tableName() string {
 	return "Location"
 }
 
-func (m Location) idName() string {
+func (m *Location) idName() string {
 	return "LocationId"
 }
 
-func (m Location) scanRow(rows *sql.Rows) (model, error) {
+func (m *Location) scanRow(rows *sql.Rows) (model, error) {
 	err := rows.Scan(&m.LocationID, &m.BookNumber, &m.ChapterNumber, &m.DocumentID, &m.Track,
 		&m.IssueTagNumber, &m.KeySymbol, &m.MepsLanguage, &m.LocationType, &m.Title)
 	return m, err
 }
 
 // makeSlice converts a slice of the generice interface model
-func (Location) makeSlice(mdl []model) []Location {
-	result := make([]Location, len(mdl))
+func (Location) makeSlice(mdl []*model) []*Location {
+	result := make([]*Location, len(mdl))
 	for i := range mdl {
 		if mdl[i] != nil {
-			result[i] = mdl[i].(Location)
+			result[i] = (*mdl[i]).(*Location)
 		}
 	}
 	return result

--- a/model/Note.go
+++ b/model/Note.go
@@ -16,30 +16,30 @@ type Note struct {
 }
 
 // ID returns the ID of the entry
-func (m Note) ID() int {
+func (m *Note) ID() int {
 	return m.NoteID
 }
 
-func (m Note) tableName() string {
+func (m *Note) tableName() string {
 	return "Note"
 }
 
-func (m Note) idName() string {
+func (m *Note) idName() string {
 	return "NoteId"
 }
 
-func (m Note) scanRow(rows *sql.Rows) (model, error) {
+func (m *Note) scanRow(rows *sql.Rows) (model, error) {
 	err := rows.Scan(&m.NoteID, &m.GUID, &m.UserMarkID, &m.LocationID, &m.Title, &m.Content,
 		&m.LastModified, &m.BlockType, &m.BlockIdentifier)
 	return m, err
 }
 
 // makeSlice converts a slice of the generice interface model
-func (Note) makeSlice(mdl []model) []Note {
-	result := make([]Note, len(mdl))
+func (Note) makeSlice(mdl []*model) []*Note {
+	result := make([]*Note, len(mdl))
 	for i := range mdl {
 		if mdl[i] != nil {
-			result[i] = mdl[i].(Note)
+			result[i] = (*mdl[i]).(*Note)
 		}
 	}
 	return result

--- a/model/Tag.go
+++ b/model/Tag.go
@@ -11,31 +11,31 @@ type Tag struct {
 }
 
 // ID returns the ID of the entry
-func (m Tag) ID() int {
+func (m *Tag) ID() int {
 	return m.TagID
 }
 
-func (m Tag) tableName() string {
+func (m *Tag) tableName() string {
 	return "Tag"
 }
 
-func (m Tag) idName() string {
+func (m *Tag) idName() string {
 	return "TagId"
 }
 
-func (m Tag) scanRow(rows *sql.Rows) (model, error) {
+func (m *Tag) scanRow(rows *sql.Rows) (model, error) {
 	err := rows.Scan(&m.TagID, &m.TagType, &m.Name, &m.ImageFilename)
 	return m, err
 }
 
 // makeSlice converts a slice of the generice interface model
-func (Tag) makeSlice(mdl []model) []Tag {
-	result := make([]Tag, len(mdl))
+func (Tag) makeSlice(mdl []*model) []*Tag {
+	result := make([]*Tag, len(mdl))
 	for i := range mdl {
 		if mdl[i] == nil {
 			continue
 		}
-		tag := mdl[i].(Tag)
+		tag := (*mdl[i]).(*Tag)
 
 		// The "Favorite" tag is already included with a fresh JW-Library installation
 		if tag.TagID == 1 && tag.TagType == 0 && tag.Name == "Favorite" {

--- a/model/TagMap.go
+++ b/model/TagMap.go
@@ -13,29 +13,29 @@ type TagMap struct {
 }
 
 // ID returns the ID of the entry
-func (m TagMap) ID() int {
+func (m *TagMap) ID() int {
 	return m.TagMapID
 }
 
-func (m TagMap) tableName() string {
+func (m *TagMap) tableName() string {
 	return "TagMap"
 }
 
-func (m TagMap) idName() string {
+func (m *TagMap) idName() string {
 	return "TagMapId"
 }
 
-func (m TagMap) scanRow(rows *sql.Rows) (model, error) {
+func (m *TagMap) scanRow(rows *sql.Rows) (model, error) {
 	err := rows.Scan(&m.TagMapID, &m.PlaylistItemID, &m.LocationID, &m.NoteID, &m.TagID, &m.Position)
 	return m, err
 }
 
 // makeSlice converts a slice of the generice interface model
-func (TagMap) makeSlice(mdl []model) []TagMap {
-	result := make([]TagMap, len(mdl))
+func (TagMap) makeSlice(mdl []*model) []*TagMap {
+	result := make([]*TagMap, len(mdl))
 	for i := range mdl {
 		if mdl[i] != nil {
-			result[i] = mdl[i].(TagMap)
+			result[i] = (*mdl[i]).(*TagMap)
 		}
 	}
 	return result

--- a/model/UserMark.go
+++ b/model/UserMark.go
@@ -13,29 +13,29 @@ type UserMark struct {
 }
 
 // ID returns the ID of the entry
-func (m UserMark) ID() int {
+func (m *UserMark) ID() int {
 	return m.UserMarkID
 }
 
-func (m UserMark) tableName() string {
+func (m *UserMark) tableName() string {
 	return "UserMark"
 }
 
-func (m UserMark) idName() string {
+func (m *UserMark) idName() string {
 	return "UserMarkId"
 }
 
-func (m UserMark) scanRow(rows *sql.Rows) (model, error) {
+func (m *UserMark) scanRow(rows *sql.Rows) (model, error) {
 	err := rows.Scan(&m.UserMarkID, &m.ColorIndex, &m.LocationID, &m.StyleIndex, &m.UserMarkGUID, &m.Version)
 	return m, err
 }
 
 // makeSlice converts a slice of the generice interface model
-func (UserMark) makeSlice(mdl []model) []UserMark {
-	result := make([]UserMark, len(mdl))
+func (UserMark) makeSlice(mdl []*model) []*UserMark {
+	result := make([]*UserMark, len(mdl))
 	for i := range mdl {
 		if mdl[i] != nil {
-			result[i] = mdl[i].(UserMark)
+			result[i] = (*mdl[i]).(*UserMark)
 		}
 	}
 	return result

--- a/model/model.go
+++ b/model/model.go
@@ -13,7 +13,7 @@ type model interface {
 	scanRow(row *sql.Rows) (model, error)
 }
 
-// makeModelSclie converts a slice of model-implementing structs to []model
+// makeModelSclie converts a slice of pointers of model-implementing structs to []model
 func makeModelSlice(arg interface{}) ([]model, error) {
 	slice := reflect.ValueOf(arg)
 


### PR DESCRIPTION
:recycle: By using pointers to the structs instead of the structs themself, we are able to easily update the structs directly when merging entries. This should also give us a performance boost, as we need to copy less data back-and-forth, especially if there are a lot of entries.

:bulb: Also added some more comments to clarify how some functionality is working. Especially when using reflection it can become quite confusing otherwise.