### PR TITLE
:lipstick: CLI: Adapt to terminal width

### DIFF
--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -8,6 +8,7 @@ import (
 	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/AndreasSko/go-jwlm/merger"
 	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/buger/goterm"
 	"github.com/jedib0t/go-pretty/table"
 	"github.com/spf13/cobra"
 
@@ -158,10 +159,22 @@ func handleMergeConflict(conflicts map[string]merger.MergeConflict, leftDB *mode
 	for key, conflict := range conflicts {
 		t := table.NewWriter()
 		t.SetStyle(table.StyleRounded)
+		t.Style().Options = table.Options{
+			DrawBorder:      true,
+			SeparateColumns: true,
+			SeparateFooter:  true,
+			SeparateHeader:  true,
+			SeparateRows:    true,
+		}
 
 		t.SetOutputMirror(os.Stdout)
-		t.AppendHeader(table.Row{"Left", "Right"})
-		t.AppendRow([]interface{}{conflict.Left.PrettyPrint(leftDB), conflict.Right.PrettyPrint(rightDB)})
+		if goterm.Width() >= 190 {
+			t.AppendHeader(table.Row{"Left", "Right"})
+			t.AppendRow([]interface{}{conflict.Left.PrettyPrint(leftDB), conflict.Right.PrettyPrint(rightDB)})
+		} else {
+			t.AppendRows([]table.Row{{"Left"}, {conflict.Left.PrettyPrint(leftDB)}, {"Right"}, {conflict.Right.PrettyPrint(rightDB)}})
+		}
+
 		t.Render()
 
 		fmt.Print("\n\n")

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/AlecAivazis/survey/v2 v2.1.1
 	github.com/DATA-DOG/go-sqlmock v1.5.0
+	github.com/buger/goterm v0.0.0-20200322175922-2f3e71b85129
 	github.com/go-openapi/strfmt v0.19.5 // indirect
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
 	github.com/mattn/go-isatty v0.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
+github.com/buger/goterm v0.0.0-20200322175922-2f3e71b85129 h1:gfAMKE626QEuKG3si0pdTRcr/YEbBoxY+3GOH3gWvl4=
+github.com/buger/goterm v0.0.0-20200322175922-2f3e71b85129/go.mod h1:u9UyCz2eTrSGy6fbupqJ54eY5c4IC8gREQ1053dK12U=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/model/Model.go
+++ b/model/Model.go
@@ -54,12 +54,12 @@ Loop:
 		}
 		switch field.Interface().(type) {
 		case string:
-			fmt.Fprintf(w, "\n%s:\t%s", fieldName, strings.ReplaceAll(wordwrap.WrapString(field.String(), 80), "\n", "\n\t"))
+			fmt.Fprintf(w, "\n%s:\t%s", fieldName, strings.ReplaceAll(wordwrap.WrapString(field.String(), 70), "\n", "\n\t"))
 		case sql.NullString:
 			if field.Field(1).Bool() == false {
 				continue Loop
 			}
-			fmt.Fprintf(w, "\n%s:\t%s", fieldName, strings.ReplaceAll(wordwrap.WrapString(field.Field(0).String(), 80), "\n", "\n\t"))
+			fmt.Fprintf(w, "\n%s:\t%s", fieldName, strings.ReplaceAll(wordwrap.WrapString(field.Field(0).String(), 70), "\n", "\n\t"))
 		case int:
 			fmt.Fprintf(w, "\n%s:\t%d", fieldName, field.Int())
 		case sql.NullInt32:


### PR DESCRIPTION
If terminal width is less than 190, the entries are displayed stacked, not next to each other. A more responsive approach is still preferred, but that is something for the future :)

Also changed the max. line length to 70.