### PR TITLE
GoReleaser: Release to Homebrew

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,7 +26,3 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: coverage.lcov
-      - name: Codecov
-        uses: codecov/codecov-action@v1
-        with:
-          file: profile.cov

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ on:
   push:
     tags:
       - '*'
+    paths:
+      - ".github/workflows/release.yml"
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -12,4 +14,4 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run GoReleaser
-        run: docker run -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} --rm --privileged -v $GITHUB_WORKSPACE:/go/src/github.com/AndreasSko/go-jwlm -v /var/run/docker.sock:/var/run/docker.sock -w /go/src/github.com/AndreasSko/go-jwlm mailchain/goreleaser-xcgo --rm-dist
+        run: docker run -e GITHUB_TOKEN=${{ secrets.GORELEASER_GITHUB_TOKEN }} --rm --privileged -v $GITHUB_WORKSPACE:/go/src/github.com/AndreasSko/go-jwlm -v /var/run/docker.sock:/var/run/docker.sock -w /go/src/github.com/AndreasSko/go-jwlm mailchain/goreleaser-xcgo --rm-dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,3 +46,9 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
+brews:
+  - name: go-jwlm
+    tap:
+      owner: andreassko
+      name: homebrew-go-jwlm
+    homepage: https://github.com/AndreasSko/go-jwlm


### PR DESCRIPTION
So Mac users are able to install go-jwlm with a simple `brew install andreassko/homebrew-go-jwlm/go-jwlm`