### PR TITLE
Automatically solve conflicts with chooseLeft, chooseRight, and chooseNewest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,73 @@
-[![Coverage Status](https://coveralls.io/repos/github/AndreasSko/go-jwlm/badge.svg?branch=master)](https://coveralls.io/github/AndreasSko/go-jwlm?branch=master)
+[![Coverage
+Status](https://coveralls.io/repos/github/AndreasSko/go-jwlm/badge.svg?branch=master)](https://coveralls.io/github/AndreasSko/go-jwlm?branch=master)
 
 # go-jwlm
 A command line tool to easily merge JW Library backups, written in Go.
 
-go-jwlm allows you to merge two .jwlibrary backup files, while giving you control of the process - your notes are precious, and you shouldn‘t need to trust a program solving possible merge conflicts for you.
+go-jwlm allows you to merge two .jwlibrary backup files, while giving you
+control of the process - your notes are precious, and you shouldn‘t need to
+trust a program solving possible merge conflicts for you.
 
-I created this project with the goal of having a tool that is able to work on multiple operating systems, and even allowing it to be incorporated in other programs as a library (like an iOS app) in the future. It is - and will be for quite some time - a work-in-progress project, so I‘m always open for suggestion and especially reports if you encounter an unexpected behaviour or other bugs. 
+I created this project with the goal of having a tool that is able to work on
+multiple operating systems, and even allowing it to be incorporated in other
+programs as a library (like an iOS app) in the future. It is - and will be for
+quite some time - a work-in-progress project, so I‘m always open for suggestion
+and especially reports if you encounter an unexpected behaviour or other bugs. 
 
-The usage is pretty simple: you have one command, you name your backup files - and press enter. The tool will merge all entries for you. If it encounters a conflict (like the same note with different content or two markings that overlap), it will ask you for directions: should it choose the left version or the right one? After that is finished, you have a nicely merged backup that you can import into your JW Library App. The first merge process might take some time because of the number of possible conflicts, depending on how far apart you backups are. But if you merge them regularly, it should be a matter of seconds :) 
+The usage is pretty simple: you have one command, you name your backup files -
+and press enter. The tool will merge all entries for you. If it encounters a
+conflict (like the same note with different content or two markings that
+overlap), it will ask you for directions: should it choose the left version or
+the right one? After that is finished, you have a nicely merged backup that you
+can import into your JW Library App. The first merge process might take some
+time because of the number of possible conflicts, depending on how far apart you
+backups are. But if you merge them regularly, it should be a matter of seconds
+:) 
 
 ## Usage
-`go-jwlm merge <left-backup> <right-backup> <merged-backup>`
+```shell
+go-jwlm merge <left-backup> <right-backup> <merged-backup>
+```
 
-If a conflict occurs while merging, the tool will ask for directions: should it choose the left version or the right one. For that, it shows you the actual entries (I‘m planning to improve that view and add more information, especially about publications, in the future). If you are not sure what to do, press `?`  for help. 
+If a conflict occurs while merging, the tool will ask for directions: should it
+choose the left version or the right one. For that, it shows you the actual
+entries (I‘m planning to improve that view and add more information, especially
+about publications, in the future). If you are not sure what to do, press `?`
+for help. 
+
+### Resolve conflicts automatically
+Currently, there are three solvers you can use to automatically resolve
+conflicts: `chooseLeft`, `chooseRight`, and `chooseNewest` (though the last one
+is only usable for Notes). As their names suggest, `chooseLeft` and
+`chooseRight` will always choose the same side if a conflict occurs, while
+`chooseNewest` always chooses the newest entry. 
+
+You can enable these solvers with the `--bookmarks`, `--markings`, and
+`--notes` flags:
+
+```shell
+go-jwlm merge <left-backup> <right-backup> <merged-backup> --bookmarks chooseLeft --markings chooseRight --notes chooseNewest
+```
+
+The conflict resolvers are helpful for regular merging, when you are 
+sure that one sides is always the most up-to-date one. For a first merge, 
+it is still recommended to manually solve conflicts, so you don't risk
+accidentally overwriting entries.
 
 ## Installation 
-You can find the compiled binaries for Windows, Linux, and Mac under the [Release](https://github.com/AndreasSko/go-jwlm/releases) section. In the future, I‘m planning to offer those releases via Homebrew (Mac) and Spew (Windows).
+You can find the compiled binaries for Windows, Linux, and Mac under the
+[Release](https://github.com/AndreasSko/go-jwlm/releases) section. In the
+future, I‘m planning to offer those releases via Homebrew (Mac) and Spew
+(Windows).
 
 ## A word of caution 
-It took me a while to trust my own program, but I still keep backups of my Libraries - and so should you. Go-jwlm is still in alpha-phase, so there is a possibility that something might get lost because of a yet-to-find bug. So please keep that in mind and - again - if you found a bug, feel free to open an issue. 
+It took me a while to trust my own program, but I still keep backups of my
+Libraries - and so should you. Go-jwlm is still in alpha-phase, so there is a
+possibility that something might get lost because of a yet-to-find bug. So
+please keep that in mind and - again - if you found a bug, feel free to open an
+issue. 
 
 ## Need help?
-Something is unclear, you have suggestions for documentation or you found a bug? Feel free to open an issue. I‘m happy to help, though please be patient if it takes a while for me to respond :)
+Something is unclear, you have suggestions for documentation or you found a bug?
+Feel free to open an issue. I‘m happy to help, though please be patient if it
+takes a while for me to respond :)

--- a/README.md
+++ b/README.md
@@ -56,9 +56,15 @@ accidentally overwriting entries.
 
 ## Installation 
 You can find the compiled binaries for Windows, Linux, and Mac under the
-[Release](https://github.com/AndreasSko/go-jwlm/releases) section. In the
-future, I‘m planning to offer those releases via Homebrew (Mac) and Spew
-(Windows).
+[Release](https://github.com/AndreasSko/go-jwlm/releases) section. 
+
+### Installation using Homebrew (Mac and Linux)
+go-jwlm can easily installed using Hombrew:
+```shell
+brew install andreassko/homebrew-go-jwlm/go-jwlm
+```
+
+See the instructions on how to install Homebrew at https://brew.sh
 
 ## A word of caution 
 It took me a while to trust my own program, but I still keep backups of my

--- a/merger/MergeConflictSolver.go
+++ b/merger/MergeConflictSolver.go
@@ -1,0 +1,90 @@
+package merger
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+)
+
+// MergeConflictSolver describes a function that is able to handle mergeConflicts semi-automatic
+type MergeConflictSolver func(map[string]MergeConflict) (map[string]MergeSolution, error)
+
+// SolveConflictByChoosingLeft solves a MergeConflict by always choosing the left side
+func SolveConflictByChoosingLeft(conflicts map[string]MergeConflict) (map[string]MergeSolution, error) {
+	return solveConflictByChoosingSide(conflicts, LeftSide)
+}
+
+// SolveConflictByChoosingRight solves a MergeConflict by always choosing the right side
+func SolveConflictByChoosingRight(conflicts map[string]MergeConflict) (map[string]MergeSolution, error) {
+	return solveConflictByChoosingSide(conflicts, RightSide)
+}
+
+// SolveConflictByChoosingNewest solves a MergeConflict by always choosing the newest entry,
+// which is detected by the `LastModified` field. It returns an error if the field does not
+// exist
+func SolveConflictByChoosingNewest(conflicts map[string]MergeConflict) (map[string]MergeSolution, error) {
+	solution := make(map[string]MergeSolution, len(conflicts))
+
+	for key, value := range conflicts {
+		leftModified := reflect.ValueOf(value.Left).Elem().FieldByName("LastModified")
+		rightModified := reflect.ValueOf(value.Right).Elem().FieldByName("LastModified")
+
+		if !leftModified.IsValid() || !rightModified.IsValid() {
+			return nil, fmt.Errorf("Not able to use SolveConflictByChoosingNewest, as %T has no 'LastModified' field", value.Left)
+		}
+
+		leftDate, err := time.Parse("2006-01-02T15:04:05-07:00", leftModified.String())
+		if err != nil {
+			return nil, err
+		}
+		rightDate, err := time.Parse("2006-01-02T15:04:05-07:00", rightModified.String())
+		if err != nil {
+			return nil, err
+		}
+
+		if leftDate.After(rightDate) {
+			solution[key] = MergeSolution{Side: LeftSide, Solution: value.Left, Discarded: value.Right}
+		} else {
+			solution[key] = MergeSolution{Side: RightSide, Solution: value.Right, Discarded: value.Left}
+		}
+	}
+
+	return solution, nil
+}
+
+// solveConflictByChoosingSide solves a MergeConflict by always choosing the given MergeSide
+func solveConflictByChoosingSide(conflicts map[string]MergeConflict, side MergeSide) (map[string]MergeSolution, error) {
+	solution := make(map[string]MergeSolution, len(conflicts))
+
+	for key, value := range conflicts {
+		if side == LeftSide {
+			solution[key] = MergeSolution{Side: LeftSide, Solution: value.Left, Discarded: value.Right}
+		} else {
+			solution[key] = MergeSolution{Side: RightSide, Solution: value.Right, Discarded: value.Left}
+		}
+	}
+
+	return solution, nil
+}
+
+// solveEqualityMergeConflict solves conflicts that arise, if the same Model entry exists
+// on both sides. For other conflicts it returns a mergeConflictError asking the caller
+// to handle it.
+func solveEqualityMergeConflict(conflicts map[string]MergeConflict) (map[string]MergeSolution, error) {
+	solution := make(map[string]MergeSolution, len(conflicts))
+	unsolvableConflicts := map[string]MergeConflict{}
+
+	for key, value := range conflicts {
+		if value.Left.Equals(value.Right) {
+			solution[key] = MergeSolution{Side: LeftSide, Solution: value.Left, Discarded: value.Right}
+		} else {
+			unsolvableConflicts[key] = value
+		}
+	}
+
+	if len(unsolvableConflicts) != 0 {
+		return solution, MergeConflictError{Err: "Could not solve all conflicts", Conflicts: unsolvableConflicts}
+	}
+
+	return solution, nil
+}

--- a/merger/MergeConflictSolver_test.go
+++ b/merger/MergeConflictSolver_test.go
@@ -1,0 +1,148 @@
+package merger
+
+import (
+	"testing"
+
+	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSolveConflictByChoosingX(t *testing.T) {
+	conflicts := map[string]MergeConflict{
+		"bookmarkCollision": {
+			Left: &model.Bookmark{
+				Title: "LeftBookmark",
+			},
+			Right: &model.Bookmark{
+				Title: "RightBookmark",
+			},
+		},
+		"noteCollision": {
+			Left: &model.Note{
+				GUID: "LeftNote",
+			},
+			Right: &model.Note{
+				GUID: "RightNote",
+			},
+		},
+	}
+
+	// Choose left
+	expectedResult := map[string]MergeSolution{
+		"bookmarkCollision": {
+			Side: LeftSide,
+			Solution: &model.Bookmark{
+				Title: "LeftBookmark",
+			},
+			Discarded: &model.Bookmark{
+				Title: "RightBookmark",
+			},
+		},
+		"noteCollision": {
+			Side: LeftSide,
+			Solution: &model.Note{
+				GUID: "LeftNote",
+			},
+			Discarded: &model.Note{
+				GUID: "RightNote",
+			},
+		},
+	}
+
+	result, err := SolveConflictByChoosingLeft(conflicts)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResult, result)
+
+	// Choose right
+	expectedResult = map[string]MergeSolution{
+		"bookmarkCollision": {
+			Side: RightSide,
+			Solution: &model.Bookmark{
+				Title: "RightBookmark",
+			},
+			Discarded: &model.Bookmark{
+				Title: "LeftBookmark",
+			},
+		},
+		"noteCollision": {
+			Side: RightSide,
+			Solution: &model.Note{
+				GUID: "RightNote",
+			},
+			Discarded: &model.Note{
+				GUID: "LeftNote",
+			},
+		},
+	}
+
+	result, err = SolveConflictByChoosingRight(conflicts)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResult, result)
+}
+
+func TestSolveConflictByChoosingNewest(t *testing.T) {
+	conflicts := map[string]MergeConflict{
+		"leftNewer": {
+			Left: &model.Note{
+				GUID:         "Left",
+				LastModified: "2020-09-15T13:00:00+00:00",
+			},
+			Right: &model.Note{
+				GUID:         "Right",
+				LastModified: "2020-09-15T12:00:00+00:00",
+			},
+		},
+		"rightNewer": {
+			Left: &model.Note{
+				GUID:         "Left",
+				LastModified: "2020-09-15T13:00:00+00:00",
+			},
+			Right: &model.Note{
+				GUID:         "Right",
+				LastModified: "2020-09-15T13:01:00+00:00",
+			},
+		},
+	}
+
+	expectedResult := map[string]MergeSolution{
+		"leftNewer": {
+			Side: LeftSide,
+			Solution: &model.Note{
+				GUID:         "Left",
+				LastModified: "2020-09-15T13:00:00+00:00",
+			},
+			Discarded: &model.Note{
+				GUID:         "Right",
+				LastModified: "2020-09-15T12:00:00+00:00",
+			},
+		},
+		"rightNewer": {
+			Side: RightSide,
+			Solution: &model.Note{
+				GUID:         "Right",
+				LastModified: "2020-09-15T13:01:00+00:00",
+			},
+			Discarded: &model.Note{
+				GUID:         "Left",
+				LastModified: "2020-09-15T13:00:00+00:00",
+			},
+		},
+	}
+
+	result, err := SolveConflictByChoosingNewest(conflicts)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResult, result)
+
+	conflicts = map[string]MergeConflict{
+		"bookmarkCollision": {
+			Left: &model.Bookmark{
+				Title: "LeftBookmark",
+			},
+			Right: &model.Bookmark{
+				Title: "RightBookmark",
+			},
+		},
+	}
+	_, err = SolveConflictByChoosingNewest(conflicts)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Using the `chooseLeft`, `chooseRight`, and `chooseNewest` (only for Notes) resolvers, it is possible to automatically resolve merge conflicts. The resolvers can be selected per Type using flags: `--bookmarks`, `--markings`, and `--notes`:

**Example:**
```shell
go-jwlm merge <left-backup> <right-backup> <merged-backup> --bookmarks chooseLeft --markings chooseRight --notes chooseNewest
```

Added documentation in README.

Other changes:
* Wrap lines in README
* Installation using Homebrew in README