### PR TITLE
🐛 DatabaseName in manifest was ignored

### DIFF
--- a/model/Database.go
+++ b/model/Database.go
@@ -19,8 +19,6 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 )
 
-// Destination to temporarily unzip backups
-const tmpFolder = ".jwlm-tmp"
 const manifestFilename = "manifest.json"
 
 // Database represents the JW Library database as a struct
@@ -137,13 +135,12 @@ func (db *Database) Equals(other *Database) bool {
 // ImportJWLBackup unzips a given JW Library Backup file and imports the
 // included SQLite DB to the Database struct
 func (db *Database) ImportJWLBackup(filename string) error {
-	// Create tmp folder and unzip backup content there
-	if _, err := os.Stat(tmpFolder); os.IsNotExist(err) {
-		if err := os.Mkdir(tmpFolder, 0755); err != nil {
-			return errors.Wrap(err, fmt.Sprintf("Could not create temporary directory %s", tmpFolder))
-		}
+	// Create tmp folder and place all files there
+	tmp, err := ioutil.TempDir("", "go-jwlm")
+	if err != nil {
+		return errors.Wrap(err, "Error while creating temporary directory")
 	}
-	defer os.RemoveAll(tmpFolder)
+	defer os.RemoveAll(tmp)
 
 	r, err := zip.OpenReader(filename)
 	if err != nil {
@@ -158,7 +155,7 @@ func (db *Database) ImportJWLBackup(filename string) error {
 		}
 		defer fileReader.Close()
 
-		path := filepath.Join(tmpFolder, file.Name)
+		path := filepath.Join(tmp, file.Name)
 		targetFile, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, file.Mode())
 		if err != nil {
 			return err
@@ -171,7 +168,7 @@ func (db *Database) ImportJWLBackup(filename string) error {
 	}
 
 	// Import manifest
-	path := filepath.Join(tmpFolder, manifestFilename)
+	path := filepath.Join(tmp, manifestFilename)
 	manifest := manifest{}
 	if err := manifest.importManifest(path); err != nil {
 		return errors.Wrap(err, "Error while importing manifest")
@@ -183,7 +180,7 @@ func (db *Database) ImportJWLBackup(filename string) error {
 	}
 
 	// Fill the Database with actual data
-	path = filepath.Join(tmpFolder, manifest.UserDataBackup.DatabaseName)
+	path = filepath.Join(tmp, manifest.UserDataBackup.DatabaseName)
 	return db.importSQLite(path)
 }
 
@@ -321,21 +318,20 @@ func getSliceCapacity(sqlite *sql.DB, modelType Model) (int, error) {
 // ExportJWLBackup creates a .jwlibrary backup file out of a Database{} struct
 func (db *Database) ExportJWLBackup(filename string) error {
 	// Create tmp folder and place all files there
-	if _, err := os.Stat(tmpFolder); os.IsNotExist(err) {
-		if err := os.Mkdir(tmpFolder, 0755); err != nil {
-			return errors.Wrap(err, fmt.Sprintf("Could not create temporary directory %s", tmpFolder))
-		}
+	tmp, err := ioutil.TempDir("", "go-jwlm")
+	if err != nil {
+		return errors.Wrap(err, "Error while creating temporary directory")
 	}
-	defer os.RemoveAll(tmpFolder)
+	defer os.RemoveAll(tmp)
 
 	// Create user_data.db
-	dbPath := filepath.Join(tmpFolder, "user_data.db")
+	dbPath := filepath.Join(tmp, "user_data.db")
 	if err := db.saveToNewSQLite(dbPath); err != nil {
 		return errors.Wrap(err, "Could not create SQLite database for exporting")
 	}
 
 	// Create manifest.json
-	manifestPath := filepath.Join(tmpFolder, manifestFilename)
+	manifestPath := filepath.Join(tmp, manifestFilename)
 	mfst, err := generateManifest("go-jwlm", dbPath)
 	if err != nil {
 		return errors.Wrap(err, "Error while generating manifest")

--- a/model/Database_test.go
+++ b/model/Database_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -193,11 +194,11 @@ func TestDatabase_ExportJWLBackup(t *testing.T) {
 
 func Test_createEmptySQLiteDB(t *testing.T) {
 	// Create tmp folder and place all files there
-	err := os.Mkdir(tmpFolder, 0755)
+	tmp, err := ioutil.TempDir("", "go-jwlm")
 	assert.NoError(t, err)
-	defer os.RemoveAll(tmpFolder)
+	defer os.RemoveAll(tmp)
 
-	path := filepath.Join(tmpFolder, "user_data.db")
+	path := filepath.Join(tmp, "user_data.db")
 	err = createEmptySQLiteDB(path)
 	assert.NoError(t, err)
 
@@ -218,9 +219,9 @@ func Test_createEmptySQLiteDB(t *testing.T) {
 
 func TestDatabase_saveToNewSQLite(t *testing.T) {
 	// Create tmp folder and place all files there
-	err := os.Mkdir(tmpFolder, 0755)
+	tmp, err := ioutil.TempDir("", "go-jwlm")
 	assert.NoError(t, err)
-	defer os.RemoveAll(tmpFolder)
+	defer os.RemoveAll(tmp)
 
 	db := Database{
 		BlockRange: []*BlockRange{{3, 2, 13, sql.NullInt32{Int32: 0, Valid: true}, sql.NullInt32{Int32: 14, Valid: true}, 3}},
@@ -231,7 +232,7 @@ func TestDatabase_saveToNewSQLite(t *testing.T) {
 		TagMap:     []*TagMap{{2, sql.NullInt32{Int32: 0, Valid: false}, sql.NullInt32{Int32: 0, Valid: false}, sql.NullInt32{Int32: 2, Valid: true}, 2, 1}},
 		UserMark:   []*UserMark{{2, 1, 2, 0, "2C5E7B4A-4997-4EDA-9CFF-38A7599C487B", 1}},
 	}
-	path := filepath.Join(tmpFolder, "user_data.db")
+	path := filepath.Join(tmp, "user_data.db")
 	err = db.saveToNewSQLite(path)
 	assert.NoError(t, err)
 

--- a/model/manifest_test.go
+++ b/model/manifest_test.go
@@ -1,18 +1,92 @@
 package model
 
 import (
+	"fmt"
+	"io/ioutil"
 	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/tj/assert"
 )
+
+var exampleManifest = &manifest{
+	CreationDate: time.Now().Format("2006-01-02"),
+	UserDataBackup: userDataBackup{
+		LastModifiedDate: time.Now().Format("2006-01-02T15:04:05-07:00"),
+		Hash:             "f57aabf8f375aa5469e3aea2292f89d2f624b8b2d70e0e0688f9ffbd44f0cf2b",
+		DatabaseName:     "user_data.db",
+		SchemaVersion:    8,
+		DeviceName:       "go-jwlm",
+	},
+	Name:    "test",
+	Type:    0,
+	Version: 1,
+}
+
+func Test_manifest_importManifest(t *testing.T) {
+	path := filepath.Join("testdata", "manifest_correct.json")
+
+	mfst := &manifest{}
+	assert.NoError(t, mfst.importManifest(path))
+
+	expectedMfst := &manifest{
+		CreationDate: "2020-04-11",
+		UserDataBackup: userDataBackup{
+			LastModifiedDate: "2020-04-09T05:47:26+02:00",
+			Hash:             "d87a67028133cc4de5536affe1b072841def95899b7f7450a5622112b4b5e63f",
+			DatabaseName:     "user_data.db",
+			SchemaVersion:    8,
+			DeviceName:       "iPhone",
+		},
+		Name:    "UserDataBackup_2020-04-11_iPhone",
+		Type:    0,
+		Version: 1,
+	}
+	assert.Equal(t, expectedMfst, mfst)
+
+	assert.Error(t, mfst.importManifest("nonexistentpath"))
+}
 
 func Test_validateManifest(t *testing.T) {
 	path := filepath.Join("testdata", "manifest_correct.json")
-	if err := validateManifest(path); err != nil {
-		t.Error("Manifest validation should have been successful")
-	}
 
-	path = filepath.Join("testdata", "manifest_oudated.json")
-	if err := validateManifest(path); err == nil {
-		t.Error("Manifest validation should have failed")
-	}
+	mfst := manifest{}
+	assert.NoError(t, mfst.importManifest(path))
+	assert.NoError(t, mfst.validateManifest())
+
+	path = filepath.Join("testdata", "manifest_outdated.json")
+	mfst = manifest{}
+	assert.NoError(t, mfst.importManifest(path))
+	assert.Error(t, mfst.validateManifest())
+}
+
+func Test_generateManifest(t *testing.T) {
+	dbPath := filepath.Join("testdata", "user_data.db")
+
+	mfst, err := generateManifest("test", dbPath)
+	exampleManifest.UserDataBackup.LastModifiedDate = time.Now().Format("2006-01-02T15:04:05-07:00") // Could have changed in the last second..
+	assert.NoError(t, err)
+	assert.Equal(t, exampleManifest, mfst)
+
+	_, err = generateManifest("test", "nonexistent.db")
+	assert.Error(t, err)
+}
+
+func Test_exportManifest(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "go-jwlm")
+	assert.NoError(t, err)
+	//defer os.RemoveAll(tmp)
+
+	path := filepath.Join(tmp, "test_manifest.json")
+	fmt.Println(path)
+	err = exampleManifest.exportManifest(path)
+	assert.NoError(t, err)
+	assert.FileExists(t, path)
+
+	otherMfst := &manifest{}
+	err = otherMfst.importManifest(path)
+	assert.NoError(t, err)
+	assert.Equal(t, exampleManifest, otherMfst)
+
 }


### PR DESCRIPTION
When importing a backup, the DatabaseName was hard-coded to `user_data.db`, which would not work for backups exported by a JWL running on Windows (there the file is called `userData.db`.

This PR changes the handling of manifests, adding a proper import/export functionality, splitting it out of the validate method. This allows us to use the information within the manifest for other use cases (like getting the propere DatabaseName).

Other changes:
* ♻️ Use built-in ioutil.TempDir for tmp dir: Using the built-in functionality reduces the risk of unintended errors while handling temporary files.