### PR TITLE
🐛 Don't overwrite original entry while merging 

### DIFF
--- a/merger/BookmarkMerger_test.go
+++ b/merger/BookmarkMerger_test.go
@@ -132,6 +132,8 @@ func TestMergeBookmarks(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expectedResult, result)
 	assert.Equal(t, expectedChanges, changes)
+	// Check if original has not been tweaked
+	assert.Equal(t, 3, right[2].BookmarkID)
 
 	// Fail with mergeConflict
 	left = []*model.Bookmark{

--- a/merger/LocationMerger_test.go
+++ b/merger/LocationMerger_test.go
@@ -304,6 +304,9 @@ func Test_MergeLocations(t *testing.T) {
 	assert.Equal(t, expectedResult, result)
 	assert.Equal(t, expectedChanges, changes)
 	assert.NoError(t, err)
+	// Check if original has not been tweaked
+	assert.Equal(t, 6, left[6].LocationID)
+	assert.Equal(t, 7, right[7].LocationID)
 }
 
 func Benchmark_MergeLocations(b *testing.B) {

--- a/merger/Merger.go
+++ b/merger/Merger.go
@@ -181,7 +181,7 @@ func prepareMergeSolution(solutionMap *map[string]MergeSolution) ([]model.Model,
 
 	i = 1
 	for _, sol := range solutionSlice {
-		result[i] = sol.Solution
+		result[i] = model.MakeModelCopy(sol.Solution)
 		// Update ID if needed
 		if sol.Solution.ID() != i {
 			if sol.Side == LeftSide {

--- a/merger/NoteMerger_test.go
+++ b/merger/NoteMerger_test.go
@@ -134,6 +134,9 @@ func TestMergeNotes(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expectedResult, result)
 	assert.Equal(t, expectedChanges, changes)
+	// Check if original has not been tweaked
+	assert.Equal(t, 2, left[1].NoteID)
+	assert.Equal(t, 3, right[2].NoteID)
 
 	// Call Merge while some entries have been updated => conflict
 	left = []*model.Note{

--- a/merger/TagMapMerger.go
+++ b/merger/TagMapMerger.go
@@ -61,7 +61,7 @@ func MergeTagMaps(left []*model.TagMap, right []*model.TagMap, conflictSolution 
 
 		j = 0
 		for j, tm := range sortedTagMap {
-			result[i] = tm
+			result[i] = model.MakeModelCopy(tm).(*model.TagMap)
 			result[i].SetID(i)
 			// Position is defined per Tag(!), not PlaylistItemID/LocationID/NoteID
 			result[i].Position = j

--- a/merger/TagMapMerger_test.go
+++ b/merger/TagMapMerger_test.go
@@ -253,4 +253,7 @@ func TestMergeTagMaps(t *testing.T) {
 	result, _, err := MergeTagMaps(left, right, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedResult, result)
+	// Check if original has not been tweaked
+	assert.Equal(t, 12, left[11].TagMapID)
+	assert.Equal(t, 8, right[7].TagMapID)
 }

--- a/merger/TagMerger_test.go
+++ b/merger/TagMerger_test.go
@@ -123,4 +123,7 @@ func TestMergeTags(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expectedResult, result)
 	assert.Equal(t, expectedChanges, changes)
+	// Check if original has not been tweaked
+	assert.Equal(t, 1, left[0].TagID)
+	assert.Equal(t, 1, right[0].TagID)
 }

--- a/merger/UserMarkBlockRangeMerger.go
+++ b/merger/UserMarkBlockRangeMerger.go
@@ -220,14 +220,14 @@ func joinToUserMarkBlockRange(um []*model.UserMark, br []*model.BlockRange) []*m
 		if entry == nil || *entry == (model.UserMark{}) {
 			continue
 		}
-		result[i] = &model.UserMarkBlockRange{UserMark: entry, BlockRanges: []*model.BlockRange{}}
+		result[i] = &model.UserMarkBlockRange{UserMark: model.MakeModelCopy(entry).(*model.UserMark), BlockRanges: []*model.BlockRange{}}
 	}
 
 	for _, entry := range br {
 		if entry == nil || entry.UserMarkID >= len(result) || result[entry.UserMarkID] == nil {
 			continue
 		}
-		result[entry.UserMarkID].BlockRanges = append(result[entry.UserMarkID].BlockRanges, entry)
+		result[entry.UserMarkID].BlockRanges = append(result[entry.UserMarkID].BlockRanges, model.MakeModelCopy(entry).(*model.BlockRange))
 	}
 
 	return result

--- a/merger/UserMarkBlockRangeMerger_test.go
+++ b/merger/UserMarkBlockRangeMerger_test.go
@@ -222,6 +222,9 @@ func TestMergeUserMarkAndBlockRange_without_conflict(t *testing.T) {
 	assert.Equal(t, expectedUM, um)
 	assert.Equal(t, expectedBR, br)
 	assert.Equal(t, expectedChanges, changes)
+	// Check if original has not been tweaked
+	assert.Equal(t, 4, leftUM[4].UserMarkID)
+	assert.Equal(t, 4, leftBR[4].BlockRangeID)
 }
 
 func TestMergeUserMarkAndBlockRange_with_conflict(t *testing.T) {

--- a/model/Model.go
+++ b/model/Model.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/jinzhu/copier"
 	"github.com/mitchellh/go-wordwrap"
 )
 
@@ -39,6 +40,34 @@ func MakeModelSlice(arg interface{}) ([]Model, error) {
 		result[i] = slice.Index(i).Interface().(Model)
 	}
 	return result, nil
+}
+
+// MakeModelCopy copies the content of the given Model (pointer to a
+// model-implementing struct) to a new Model
+func MakeModelCopy(mdl Model) Model {
+	var mdlCopy Model
+	switch mdl.(type) {
+	case *BlockRange:
+		mdlCopy = &BlockRange{}
+	case *Bookmark:
+		mdlCopy = &Bookmark{}
+	case *Location:
+		mdlCopy = &Location{}
+	case *Note:
+		mdlCopy = &Note{}
+	case *Tag:
+		mdlCopy = &Tag{}
+	case *TagMap:
+		mdlCopy = &TagMap{}
+	case *UserMark:
+		mdlCopy = &UserMark{}
+	default:
+		panic(fmt.Sprintf("Type %T is not supported for copying", mdl))
+	}
+
+	copier.Copy(mdlCopy, mdl)
+
+	return mdlCopy
 }
 
 // prettyPrint prints the given fields of a Model as a table. If the field

--- a/model/Model_test.go
+++ b/model/Model_test.go
@@ -7,6 +7,104 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestMakeModelCopy(t *testing.T) {
+	br := &BlockRange{
+		BlockRangeID: 1,
+		BlockType:    1,
+		Identifier:   1,
+		StartToken:   sql.NullInt32{Int32: 1, Valid: true},
+		EndToken:     sql.NullInt32{Int32: 2, Valid: true},
+		UserMarkID:   1,
+	}
+	brCp := MakeModelCopy(br)
+	assert.Equal(t, br, brCp)
+	assert.NotSame(t, br, brCp)
+
+	bm := &Bookmark{
+		BookmarkID:            1,
+		LocationID:            2,
+		PublicationLocationID: 3,
+		Slot:                  4,
+		Title:                 "Test",
+		Snippet:               sql.NullString{},
+		BlockType:             0,
+		BlockIdentifier:       sql.NullInt32{},
+	}
+	bmCp := MakeModelCopy(bm)
+	assert.Equal(t, bm, bmCp)
+	assert.NotSame(t, bm, bmCp)
+
+	loc := &Location{
+		LocationID:     1,
+		BookNumber:     sql.NullInt32{Int32: 2, Valid: true},
+		ChapterNumber:  sql.NullInt32{Int32: 3, Valid: true},
+		DocumentID:     sql.NullInt32{Int32: 4, Valid: true},
+		Track:          sql.NullInt32{Int32: 5, Valid: true},
+		IssueTagNumber: 6,
+		KeySymbol:      sql.NullString{String: "nwtsty", Valid: true},
+		MepsLanguage:   7,
+		LocationType:   8,
+		Title:          sql.NullString{String: "ThisTitleShouldNotBeInUniqueKey", Valid: true},
+	}
+	locCp := MakeModelCopy(loc)
+	assert.Equal(t, loc, locCp)
+	assert.NotSame(t, loc, locCp)
+
+	note := &Note{
+		NoteID:          1,
+		GUID:            "GUIDFOR1",
+		UserMarkID:      sql.NullInt32{Int32: 1, Valid: true},
+		LocationID:      sql.NullInt32{Int32: 1, Valid: true},
+		Title:           sql.NullString{String: "A Title", Valid: true},
+		Content:         sql.NullString{String: "The content", Valid: true},
+		LastModified:    "2017-06-01T19:36:28+0200",
+		BlockType:       0,
+		BlockIdentifier: sql.NullInt32{},
+	}
+	noteCp := MakeModelCopy(note)
+	assert.Equal(t, note, noteCp)
+	assert.NotSame(t, note, noteCp)
+
+	tag := &Tag{
+		TagID:         1,
+		TagType:       1,
+		Name:          "FirstTag",
+		ImageFilename: sql.NullString{},
+	}
+	tagCp := MakeModelCopy(tag)
+	assert.Equal(t, tag, tagCp)
+	assert.NotSame(t, tag, tagCp)
+
+	tm := &TagMap{
+		TagMapID:       1,
+		PlaylistItemID: sql.NullInt32{1, true},
+		LocationID:     sql.NullInt32{1, true},
+		NoteID:         sql.NullInt32{1, true},
+		TagID:          1,
+		Position:       1,
+	}
+	tmCp := MakeModelCopy(tm)
+	assert.Equal(t, tm, tmCp)
+	assert.NotSame(t, tm, tmCp)
+
+	um := &UserMark{
+		UserMarkID:   1,
+		ColorIndex:   1,
+		LocationID:   1,
+		StyleIndex:   1,
+		UserMarkGUID: "FIRST",
+		Version:      1,
+	}
+	umCp := MakeModelCopy(um)
+	assert.Equal(t, um, umCp)
+	assert.NotSame(t, um, umCp)
+
+	assert.Panics(t, func() {
+		umbr := &UserMarkBlockRange{}
+		MakeModelCopy(umbr)
+	})
+}
+
 func TestPrettyPrint(t *testing.T) {
 	location := &Location{
 		LocationID: 1,


### PR DESCRIPTION
Previously, calling a merge function resulted in the original database entries being tweaked (mainly their IDs), as only their pointers were copied. This PR changes it to create copies of the entries and add them to the merged result, so the copied entries can be safely tweaked. This allows to re-use the same Database for multiple merge attempts.

**Changes:**
* New Function: MakeModelCopy 
* 🐛 Don't overwrite original entry while merging 