### PR TITLE
New command: Compare backup files

### DIFF
--- a/cmd/compare.go
+++ b/cmd/compare.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/AlecAivazis/survey/v2/terminal"
+	"github.com/AndreasSko/go-jwlm/model"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var compareCmd = &cobra.Command{
+	Use:     "compare <left-backup> <right-backup>",
+	Short:   "Compare two JW Library backup files to see if they are equal",
+	Example: `go-jwlm compare left.jwlibrary right.jwlibrary`,
+	Run: func(cmd *cobra.Command, args []string) {
+		leftFilename := args[0]
+		rightFilename := args[1]
+		compare(leftFilename, rightFilename, terminal.Stdio{In: os.Stdin, Out: os.Stdout, Err: os.Stderr})
+	},
+	Args: cobra.ExactArgs(2),
+}
+
+func compare(leftFilename string, rightFilename string, stdio terminal.Stdio) {
+	fmt.Fprintln(stdio.Out, "Importing left backup")
+	left := &model.Database{}
+	err := left.ImportJWLBackup(leftFilename)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Fprintln(stdio.Out, "Importing right backup")
+	right := &model.Database{}
+	err = right.ImportJWLBackup(rightFilename)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	equal := left.Equals(right)
+	if equal {
+		fmt.Fprintln(stdio.Out, "✅ Backups are equal")
+	} else {
+		fmt.Fprintln(stdio.Out, "❌ Backups are NOT equal")
+	}
+}
+
+func init() {
+	rootCmd.AddCommand(compareCmd)
+}

--- a/cmd/compare_test.go
+++ b/cmd/compare_test.go
@@ -1,0 +1,66 @@
+// +build !windows
+
+package cmd
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/AlecAivazis/survey/v2/terminal"
+	expect "github.com/Netflix/go-expect"
+	"github.com/tj/assert"
+)
+
+func Test_compare(t *testing.T) {
+	t.Parallel()
+
+	tmp, err := ioutil.TempDir("", "go-jwlm")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmp)
+
+	emptyFilename := filepath.Join(tmp, "empty.jwlibrary")
+	leftFilename := filepath.Join(tmp, "left.jwlibrary")
+	rightFilename := filepath.Join(tmp, "right.jwlibrary")
+	assert.NoError(t, emptyDB.ExportJWLBackup(emptyFilename))
+	assert.NoError(t, leftDB.ExportJWLBackup(leftFilename))
+	assert.NoError(t, rightDB.ExportJWLBackup(rightFilename))
+
+	RunCmdTest(t,
+		func(t *testing.T, c *expect.Console) {
+			_, err := c.ExpectString("Backups are NOT equal")
+			assert.NoError(t, err)
+			_, err = c.ExpectEOF()
+			assert.NoError(t, err)
+		},
+		func(t *testing.T, c *expect.Console) {
+			compare(leftFilename, emptyFilename, terminal.Stdio{In: c.Tty(), Out: c.Tty(), Err: c.Tty()})
+			time.Sleep(time.Millisecond * 150) // So it does not finish before go-expect finished
+		})
+
+	RunCmdTest(t,
+		func(t *testing.T, c *expect.Console) {
+			_, err := c.ExpectString("✅ Backups are equal")
+			assert.NoError(t, err)
+			_, err = c.ExpectEOF()
+			assert.NoError(t, err)
+		},
+		func(t *testing.T, c *expect.Console) {
+			compare(leftFilename, leftFilename, terminal.Stdio{In: c.Tty(), Out: c.Tty(), Err: c.Tty()})
+			time.Sleep(time.Millisecond * 150) // So it does not finish before go-expect finished
+		})
+
+	RunCmdTest(t,
+		func(t *testing.T, c *expect.Console) {
+			_, err := c.ExpectString("Backups are equal")
+			assert.NoError(t, err)
+			_, err = c.ExpectEOF()
+			assert.NoError(t, err)
+		},
+		func(t *testing.T, c *expect.Console) {
+			compare(rightFilename, rightFilename, terminal.Stdio{In: c.Tty(), Out: c.Tty(), Err: c.Tty()})
+			time.Sleep(time.Millisecond * 150) // So it does not finish before go-expect finished
+		})
+}

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -47,7 +47,7 @@ var MarkingResolver string
 var NoteResolver string
 
 func merge(leftFilename string, rightFilename string, mergedFilename string, stdio terminal.Stdio) {
-	fmt.Println("Importing left backup")
+	fmt.Fprintln(stdio.Out, "Importing left backup")
 	left := model.Database{}
 	err := left.ImportJWLBackup(leftFilename)
 	if err != nil {

--- a/model/Database.go
+++ b/model/Database.go
@@ -99,8 +99,6 @@ func (db *Database) Equals(other *Database) bool {
 	// Make copy of DBs so we can safely transform them if necessary
 	dbCp := MakeDatabaseCopy(db)
 	otherCp := MakeDatabaseCopy(other)
-	fmt.Println(other.BlockRange)
-	fmt.Println(otherCp.BlockRange)
 
 	// Sort all tables by UniqueKey and update IDs in other tables
 	for _, db := range []*Database{dbCp, otherCp} {


### PR DESCRIPTION
Using `go-jwlm compare <left-backup> <right-backup>` it is possible to compare two backup files to see if their contents are equal, even if the order of entries might be different. This is mainly meant for debugging (or rather ensuring that there is no bug 😅), but might be useful for other use cases.

Also fixed a tiny bug (not everything was printing to Stdio in merge command) & removed a forgotten debug statement.


**Changes:**
* 🐛 mergeCmd: Not everything printing to Stdio
* Remove forgotten debug statements
* CMD: Compare two backups
* Update & tidy dependencies