### PR TITLE
Run SQLite Vacuum when exporting

### DIFF
--- a/model/Database.go
+++ b/model/Database.go
@@ -414,6 +414,12 @@ func (db *Database) saveToNewSQLite(filename string) error {
 		}
 	}
 
+	// Vacuum to clean up SQLite DB
+	_, err = sqlite.Exec("VACUUM")
+	if err != nil {
+		return errors.Wrap(err, "Error while vacuuming SQLite DB")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
The `VACUUM` command optimizes and cleans up the SQLite DB, resulting in a decreased DB size.

Closes https://github.com/AndreasSko/go-jwlm/issues/15