### PR TITLE
🐛 Combine equal TagMap with different position

### DIFF
--- a/cmd/merge_test.go
+++ b/cmd/merge_test.go
@@ -408,7 +408,10 @@ var rightDB = &model.Database{
 			TagMapID: 2,
 			NoteID:   sql.NullInt32{2, true},
 			TagID:    3,
-			Position: 0,
+			// Should normally be 0, but changed it to 1 to detect
+			// if merger recognizes that its still the same entry,
+			// just with a different position
+			Position: 1,
 		},
 	},
 	UserMark: []*model.UserMark{

--- a/merger/TagMapMerger_test.go
+++ b/merger/TagMapMerger_test.go
@@ -85,6 +85,14 @@ func TestMergeTagMaps(t *testing.T) {
 			TagID:          101,
 			Position:       0,
 		},
+		{
+			TagMapID:       13,
+			PlaylistItemID: sql.NullInt32{},
+			LocationID:     sql.NullInt32{},
+			NoteID:         sql.NullInt32{Int32: 999, Valid: true},
+			TagID:          3,
+			Position:       3,
+		},
 	}
 
 	right := []*model.TagMap{
@@ -139,6 +147,14 @@ func TestMergeTagMaps(t *testing.T) {
 			NoteID:         sql.NullInt32{Int32: 222, Valid: true},
 			TagID:          3,
 			Position:       0,
+		},
+		{
+			TagMapID:       9,
+			PlaylistItemID: sql.NullInt32{},
+			LocationID:     sql.NullInt32{},
+			NoteID:         sql.NullInt32{Int32: 999, Valid: true},
+			TagID:          3,
+			Position:       1,
 		},
 	}
 
@@ -202,14 +218,22 @@ func TestMergeTagMaps(t *testing.T) {
 		},
 		{
 			TagMapID:       8,
-			PlaylistItemID: sql.NullInt32{Int32: 1, Valid: true},
+			PlaylistItemID: sql.NullInt32{},
 			LocationID:     sql.NullInt32{},
-			NoteID:         sql.NullInt32{},
+			NoteID:         sql.NullInt32{Int32: 999, Valid: true},
 			TagID:          3,
 			Position:       3,
 		},
 		{
 			TagMapID:       9,
+			PlaylistItemID: sql.NullInt32{Int32: 1, Valid: true},
+			LocationID:     sql.NullInt32{},
+			NoteID:         sql.NullInt32{},
+			TagID:          3,
+			Position:       4,
+		},
+		{
+			TagMapID:       10,
 			PlaylistItemID: sql.NullInt32{},
 			LocationID:     sql.NullInt32{},
 			NoteID:         sql.NullInt32{Int32: 1, Valid: true},
@@ -217,7 +241,7 @@ func TestMergeTagMaps(t *testing.T) {
 			Position:       0,
 		},
 		{
-			TagMapID:       10,
+			TagMapID:       11,
 			PlaylistItemID: sql.NullInt32{Int32: 1, Valid: true},
 			LocationID:     sql.NullInt32{},
 			NoteID:         sql.NullInt32{},
@@ -225,7 +249,7 @@ func TestMergeTagMaps(t *testing.T) {
 			Position:       0,
 		},
 		{
-			TagMapID:       11,
+			TagMapID:       12,
 			PlaylistItemID: sql.NullInt32{},
 			LocationID:     sql.NullInt32{},
 			NoteID:         sql.NullInt32{Int32: 2, Valid: true},
@@ -233,7 +257,7 @@ func TestMergeTagMaps(t *testing.T) {
 			Position:       0,
 		},
 		{
-			TagMapID:       12,
+			TagMapID:       13,
 			PlaylistItemID: sql.NullInt32{},
 			LocationID:     sql.NullInt32{},
 			NoteID:         sql.NullInt32{Int32: 1, Valid: true},
@@ -241,7 +265,7 @@ func TestMergeTagMaps(t *testing.T) {
 			Position:       0,
 		},
 		{
-			TagMapID:       13,
+			TagMapID:       14,
 			PlaylistItemID: sql.NullInt32{},
 			LocationID:     sql.NullInt32{},
 			NoteID:         sql.NullInt32{Int32: 1, Valid: true},

--- a/model/TagMap.go
+++ b/model/TagMap.go
@@ -38,9 +38,6 @@ func (m *TagMap) UniqueKey() string {
 	sb.WriteString(strconv.FormatInt(int64(m.NoteID.Int32), 10))
 	sb.WriteString("_")
 	sb.WriteString(strconv.FormatInt(int64(m.TagID), 10))
-	sb.WriteString("_")
-	sb.WriteString(strconv.FormatInt(int64(m.Position), 10))
-	// TODO: Should TagID & Position be included??
 	return sb.String()
 }
 

--- a/model/TagMap_test.go
+++ b/model/TagMap_test.go
@@ -41,9 +41,9 @@ func TestTagMap_UniqueKey(t *testing.T) {
 		TagID:      1,
 		Position:   1,
 	}
-	assert.Equal(t, "1_1_1_1_1", m1.UniqueKey())
+	assert.Equal(t, "1_1_1_1", m1.UniqueKey())
 	assert.Equal(t, m1.UniqueKey(), m1_1.UniqueKey())
-	assert.Equal(t, "0_1_1_1_1", m2.UniqueKey())
+	assert.Equal(t, "0_1_1_1", m2.UniqueKey())
 }
 
 func TestTagMap_Equals(t *testing.T) {


### PR DESCRIPTION
Because the position of a TagMap was included in the uniqueKey, the same TagMap with a different position would be considered as a different TagMap entry, resulting in a possible

> UNIQUE constraint failed: TagMap.TagId, TagMap.NoteId

error.

This removes the position from the uniqueKey of TagMaps and adds tests to detect the problem in the future.