### PR TITLE
🐛 Ignore unrelated solutions

### DIFF
--- a/merger/UserMarkBlockRangeMerger.go
+++ b/merger/UserMarkBlockRangeMerger.go
@@ -168,6 +168,15 @@ func replaceUMBRConflictsWithSolution(left *[]*model.UserMarkBlockRange, right *
 
 	for _, sol := range conflictSolution {
 		var side, other *[]*model.UserMarkBlockRange
+
+		// Ignore non UserMarkBlockRange solutions
+		if _, ok := sol.Solution.(*model.UserMarkBlockRange); !ok {
+			continue
+		}
+		if _, ok := sol.Discarded.(*model.UserMarkBlockRange); !ok {
+			continue
+		}
+
 		if sol.Side == LeftSide {
 			side = left
 			other = right

--- a/merger/UserMarkBlockRangeMerger_test.go
+++ b/merger/UserMarkBlockRangeMerger_test.go
@@ -1336,6 +1336,15 @@ func Test_replaceUMBRConflictsWithSolution(t *testing.T) {
 				},
 			},
 		},
+		"UNRELATEDSOLUTION": {
+			Side: RightSide,
+			Solution: &model.Note{
+				GUID: "BLA",
+			},
+			Discarded: &model.Note{
+				GUID: "BLABLA",
+			},
+		},
 	}
 
 	expectedLeft := []*model.UserMarkBlockRange{


### PR DESCRIPTION
When merging `UserMarkBlockRanges` with solutions that were not of type `UserMarkBlockRange`, the function would fail with a `interface conversion` panic. With this change, it simply skips unrelated solutions. Added test case.