### PR TITLE
✨ Mobile wrapper using Gomobile

### DIFF
--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -85,7 +85,7 @@ func merge(leftFilename string, rightFilename string, mergedFilename string, std
 		case merger.MergeConflictError:
 			if BookmarkResolver != "" {
 				var resErr error
-				bookmarksConflictSolution, resErr = autoResolveConflicts(err.Conflicts, BookmarkResolver)
+				bookmarksConflictSolution, resErr = merger.AutoResolveConflicts(err.Conflicts, BookmarkResolver)
 				if resErr != nil {
 					log.Fatal(resErr)
 				}
@@ -130,7 +130,7 @@ func merge(leftFilename string, rightFilename string, mergedFilename string, std
 		case merger.MergeConflictError:
 			if MarkingResolver != "" {
 				var resErr error
-				UMBRConflictSolution, resErr = autoResolveConflicts(err.Conflicts, MarkingResolver)
+				UMBRConflictSolution, resErr = merger.AutoResolveConflicts(err.Conflicts, MarkingResolver)
 				if resErr != nil {
 					log.Fatal(resErr)
 				}
@@ -156,7 +156,7 @@ func merge(leftFilename string, rightFilename string, mergedFilename string, std
 		case merger.MergeConflictError:
 			if NoteResolver != "" {
 				var resErr error
-				notesConflictSolution, resErr = autoResolveConflicts(err.Conflicts, NoteResolver)
+				notesConflictSolution, resErr = merger.AutoResolveConflicts(err.Conflicts, NoteResolver)
 				if resErr != nil {
 					log.Fatal(resErr)
 				}
@@ -257,38 +257,6 @@ func handleMergeConflict(conflicts map[string]merger.MergeConflict, mergedDB *mo
 	}
 
 	return result
-}
-
-// autoResolveConflicts resolves mergeConflicts using the resolver
-// indicated by resolverName.
-func autoResolveConflicts(conflicts map[string]merger.MergeConflict, resolverName string) (map[string]merger.MergeSolution, error) {
-	resolver, err := getResolver(resolverName)
-	if err != nil {
-		return nil, err
-	}
-	if resolver == nil {
-		return nil, nil
-	}
-	return resolver(conflicts)
-}
-
-// getResolver parses the name of the resolver and returns its function.
-// If the name is empty, it returns nil.
-func getResolver(name string) (merger.MergeConflictSolver, error) {
-	if name == "" {
-		return nil, nil
-	}
-
-	switch name {
-	case "chooseLeft":
-		return merger.SolveConflictByChoosingLeft, nil
-	case "chooseRight":
-		return merger.SolveConflictByChoosingRight, nil
-	case "chooseNewest":
-		return merger.SolveConflictByChoosingNewest, nil
-	}
-
-	return nil, fmt.Errorf("%s is not a valid conflict resolver. Can be 'chooseNewest', 'chooseLeft', or 'chooseRight'", name)
 }
 
 func init() {

--- a/cmd/merge_test.go
+++ b/cmd/merge_test.go
@@ -8,8 +8,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"reflect"
-	"runtime"
 	"testing"
 
 	"github.com/AlecAivazis/survey/v2/terminal"
@@ -138,35 +136,6 @@ func RunCmdTest(t *testing.T, procedure func(*testing.T, *expect.Console), test 
 
 	// Dump the terminal's screen.
 	t.Logf("\n%s", expect.StripTrailingEmptyLines(state.String()))
-}
-
-func Test_getResolver(t *testing.T) {
-	resolver, err := getResolver("")
-	assert.NoError(t, err)
-	assert.Nil(t, resolver)
-
-	// https://github.com/stretchr/testify/issues/182#issuecomment-495359313
-	resolver, err = getResolver("chooseLeft")
-	assert.NoError(t, err)
-	assert.Equal(t,
-		"github.com/AndreasSko/go-jwlm/merger.SolveConflictByChoosingLeft",
-		runtime.FuncForPC(reflect.ValueOf(resolver).Pointer()).Name())
-
-	resolver, err = getResolver("chooseRight")
-	assert.NoError(t, err)
-	assert.Equal(t,
-		"github.com/AndreasSko/go-jwlm/merger.SolveConflictByChoosingRight",
-		runtime.FuncForPC(reflect.ValueOf(resolver).Pointer()).Name())
-
-	resolver, err = getResolver("chooseNewest")
-	assert.NoError(t, err)
-	assert.Equal(t,
-		"github.com/AndreasSko/go-jwlm/merger.SolveConflictByChoosingNewest",
-		runtime.FuncForPC(reflect.ValueOf(resolver).Pointer()).Name())
-
-	resolver, err = getResolver("nonexistent")
-	assert.EqualError(t, err, "nonexistent is not a valid conflict resolver. Can be 'chooseNewest', 'chooseLeft', or 'chooseRight'")
-	assert.Nil(t, resolver)
 }
 
 var emptyDB = &model.Database{}

--- a/go.sum
+++ b/go.sum
@@ -369,6 +369,7 @@ golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
+golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028 h1:4+4C/Iv2U4fMZBiMCc98MG1In4gJY5YRhtpDNeDeHWs=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=

--- a/gomobile/Database.go
+++ b/gomobile/Database.go
@@ -1,0 +1,68 @@
+package gomobile
+
+import (
+	"errors"
+
+	"github.com/AndreasSko/go-jwlm/model"
+)
+
+// DatabaseWrapper wraps the left, right, and merged
+// Database structs so they can be used with Gomobile.
+type DatabaseWrapper struct {
+	left   *model.Database
+	right  *model.Database
+	merged *model.Database
+
+	// Temporary databases allow to run a merge function multiple
+	// times without changing the content of the original databases.
+	leftTmp  *model.Database
+	rightTmp *model.Database
+}
+
+// ImportJWLBackup imports a .jwlibrary backup file into the struct
+// on the given side.
+func (dbw *DatabaseWrapper) ImportJWLBackup(filename string, side string) error {
+	db := &model.Database{}
+
+	if err := db.ImportJWLBackup(filename); err != nil {
+		return err
+	}
+
+	switch side {
+	case "leftSide":
+		dbw.left = db
+	case "rightSide":
+		dbw.right = db
+	default:
+		return errors.New("Only leftSide and rightSide are valid for importing backups")
+	}
+
+	return nil
+}
+
+// Init initializes the DatabaseWrapper to prepare for subsequent
+// function calls. Should be called after ImportJWLBackup.
+func (dbw *DatabaseWrapper) Init() {
+	dbw.leftTmp = model.MakeDatabaseCopy(dbw.left)
+	dbw.rightTmp = model.MakeDatabaseCopy(dbw.right)
+	dbw.merged = &model.Database{}
+}
+
+// DBIsLoaded indicates if a DB on the given side has been loaded.
+func (dbw *DatabaseWrapper) DBIsLoaded(side string) bool {
+	switch side {
+	case "leftSide":
+		return dbw.left != nil
+	case "rightSide":
+		return dbw.right != nil
+	case "mergeSide":
+		return dbw.merged != nil
+	}
+
+	return false
+}
+
+// ExportMerged exports the merged database to filename.
+func (dbw *DatabaseWrapper) ExportMerged(filename string) error {
+	return dbw.merged.ExportJWLBackup(filename)
+}

--- a/gomobile/Database_test.go
+++ b/gomobile/Database_test.go
@@ -1,0 +1,95 @@
+package gomobile
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/tj/assert"
+)
+
+var backupFile = filepath.Join("..", "model", "testdata", "backup.jwlibrary")
+
+func TestDatabaseWrapper_ImportJWLBackup(t *testing.T) {
+	dbw := &DatabaseWrapper{}
+
+	assert.Error(t, dbw.ImportJWLBackup("wrongFile", "leftSide"))
+	assert.NoError(t, dbw.ImportJWLBackup(backupFile, "leftSide"))
+	assert.NoError(t, dbw.ImportJWLBackup(backupFile, "rightSide"))
+	assert.EqualError(t, dbw.ImportJWLBackup(backupFile, "wrongSide"), "Only leftSide and rightSide are valid for importing backups")
+
+	assert.Len(t, dbw.left.BlockRange, 5)
+	assert.Len(t, dbw.left.Bookmark, 3)
+	assert.Len(t, dbw.left.Location, 8)
+	assert.Len(t, dbw.left.Note, 3)
+	assert.Len(t, dbw.left.Tag, 3)
+	assert.Len(t, dbw.left.TagMap, 3)
+	assert.Len(t, dbw.left.UserMark, 5)
+
+	assert.True(t, dbw.left.Equals(dbw.right))
+}
+
+func TestDatabaseWrapper_Init(t *testing.T) {
+	dbw := &DatabaseWrapper{}
+
+	assert.NoError(t, dbw.ImportJWLBackup(backupFile, "leftSide"))
+	assert.NoError(t, dbw.ImportJWLBackup(backupFile, "rightSide"))
+
+	dbw.Init()
+
+	assert.True(t, dbw.merged.Equals(&model.Database{}))
+	assert.True(t, dbw.leftTmp.Equals(dbw.left))
+	assert.True(t, dbw.rightTmp.Equals(dbw.right))
+
+	dbw.leftTmp.Bookmark[1].Title = "Tweaked"
+	assert.False(t, dbw.leftTmp.Equals(dbw.left))
+
+	dbw.merged = model.MakeDatabaseCopy(dbw.left)
+	dbw.Init()
+	assert.True(t, dbw.merged.Equals(&model.Database{}))
+	assert.True(t, dbw.leftTmp.Equals(dbw.left))
+	assert.True(t, dbw.rightTmp.Equals(dbw.right))
+}
+
+func TestDatabaseWrapper_DBIsLoaded(t *testing.T) {
+	dbw := &DatabaseWrapper{}
+
+	assert.False(t, dbw.DBIsLoaded("leftSide"))
+	assert.False(t, dbw.DBIsLoaded("rightSide"))
+	assert.False(t, dbw.DBIsLoaded("mergeSide"))
+
+	assert.NoError(t, dbw.ImportJWLBackup(backupFile, "leftSide"))
+	assert.True(t, dbw.DBIsLoaded("leftSide"))
+	assert.False(t, dbw.DBIsLoaded("rightSide"))
+	assert.False(t, dbw.DBIsLoaded("mergeSide"))
+
+	assert.NoError(t, dbw.ImportJWLBackup(backupFile, "rightSide"))
+	assert.True(t, dbw.DBIsLoaded("leftSide"))
+	assert.True(t, dbw.DBIsLoaded("rightSide"))
+	assert.False(t, dbw.DBIsLoaded("mergeSide"))
+
+	dbw.merged = model.MakeDatabaseCopy(dbw.left)
+	assert.True(t, dbw.DBIsLoaded("mergeSide"))
+
+	assert.False(t, dbw.DBIsLoaded("wrongSide"))
+}
+
+func TestDatabaseWrapper_ExportMerged(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "go-jwlm")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmp)
+
+	dbw := &DatabaseWrapper{}
+	dbw.merged = &model.Database{}
+
+	assert.NoError(t, dbw.merged.ImportJWLBackup(backupFile))
+
+	newBackup := filepath.Join(tmp, "test.jwlibrary")
+	assert.NoError(t, dbw.ExportMerged(newBackup))
+
+	newDB := &model.Database{}
+	assert.NoError(t, newDB.ImportJWLBackup(newBackup))
+	assert.True(t, dbw.merged.Equals(newDB))
+}

--- a/gomobile/Merge.go
+++ b/gomobile/Merge.go
@@ -1,0 +1,141 @@
+package gomobile
+
+import (
+	"github.com/AndreasSko/go-jwlm/merger"
+	"github.com/pkg/errors"
+)
+
+// MergeLocations merges locations
+func (dbw *DatabaseWrapper) MergeLocations() error {
+	mergedLocations, locationIDChanges, err := merger.MergeLocations(dbw.leftTmp.Location, dbw.rightTmp.Location)
+	if err != nil {
+		return errors.Wrap(err, "Could not merge locations")
+	}
+	dbw.merged.Location = mergedLocations
+	merger.UpdateLRIDs(dbw.leftTmp.Bookmark, dbw.rightTmp.Bookmark, "LocationID", locationIDChanges)
+	merger.UpdateLRIDs(dbw.leftTmp.Bookmark, dbw.rightTmp.Bookmark, "PublicationLocationID", locationIDChanges)
+	merger.UpdateLRIDs(dbw.leftTmp.Note, dbw.rightTmp.Note, "LocationID", locationIDChanges)
+	merger.UpdateLRIDs(dbw.leftTmp.TagMap, dbw.rightTmp.TagMap, "LocationID", locationIDChanges)
+	merger.UpdateLRIDs(dbw.leftTmp.UserMark, dbw.rightTmp.UserMark, "LocationID", locationIDChanges)
+
+	return nil
+}
+
+// MergeBookmarks merges bookmarks
+func (dbw *DatabaseWrapper) MergeBookmarks(conflictSolver string, mcw *MergeConflictsWrapper) error {
+	var conflictSolution = mcw.solutions
+	for {
+		merged, _, err := merger.MergeBookmarks(dbw.leftTmp.Bookmark, dbw.rightTmp.Bookmark, conflictSolution)
+		if err == nil {
+			dbw.merged.Bookmark = merged
+			break
+		}
+		switch err := err.(type) {
+		case merger.MergeConflictError:
+			if conflictSolver == "" {
+				mcw.addConflicts(err.Conflicts)
+				return MergeConflictError{}
+			}
+			var resErr error
+			conflictSolution, resErr = merger.AutoResolveConflicts(err.Conflicts, conflictSolver)
+			if resErr != nil {
+				return errors.Wrap(err, "Could not automatically solve conflicts for bookmarks")
+			}
+		default:
+			return errors.Wrap(err, "Could not merge bookmarks")
+		}
+	}
+
+	return nil
+}
+
+// MergeTags merges tags
+func (dbw *DatabaseWrapper) MergeTags() error {
+	var conflictSolution map[string]merger.MergeSolution
+	for {
+		merged, idChanges, err := merger.MergeTags(dbw.leftTmp.Tag, dbw.rightTmp.Tag, conflictSolution)
+		if err == nil {
+			dbw.merged.Tag = merged
+			merger.UpdateLRIDs(dbw.leftTmp.TagMap, dbw.rightTmp.TagMap, "TagID", idChanges)
+			break
+		}
+		return errors.Wrap(err, "Could not merge tags")
+	}
+
+	return nil
+}
+
+// MergeUserMarkAndBlockRange merges UserMarks and BlockRanges
+func (dbw *DatabaseWrapper) MergeUserMarkAndBlockRange(conflictSolver string, mcw *MergeConflictsWrapper) error {
+	var conflictSolution = mcw.solutions
+	for {
+		mergedUserMarks, mergedBlockRanges, idChanges, err := merger.MergeUserMarkAndBlockRange(dbw.leftTmp.UserMark, dbw.leftTmp.BlockRange, dbw.rightTmp.UserMark, dbw.rightTmp.BlockRange, conflictSolution)
+		if err == nil {
+			dbw.merged.UserMark = mergedUserMarks
+			dbw.merged.BlockRange = mergedBlockRanges
+			merger.UpdateLRIDs(dbw.leftTmp.Note, dbw.rightTmp.Note, "UserMarkID", idChanges)
+			break
+		}
+		switch err := err.(type) {
+		case merger.MergeConflictError:
+			if conflictSolver == "" {
+				mcw.addConflicts(err.Conflicts)
+				return MergeConflictError{}
+			}
+			var resErr error
+			conflictSolution, resErr = merger.AutoResolveConflicts(err.Conflicts, conflictSolver)
+			if resErr != nil {
+				return errors.Wrap(err, "Could not automatically solve conflicts for markings")
+			}
+		default:
+			return errors.Wrap(err, "Could not merge markings")
+		}
+	}
+
+	return nil
+}
+
+// MergeNotes merges notes
+func (dbw *DatabaseWrapper) MergeNotes(conflictSolver string, mcw *MergeConflictsWrapper) error {
+	var conflictSolution = mcw.solutions
+	for {
+		merged, idChanges, err := merger.MergeNotes(dbw.leftTmp.Note, dbw.rightTmp.Note, conflictSolution)
+		if err == nil {
+			dbw.merged.Note = merged
+			merger.UpdateLRIDs(dbw.leftTmp.TagMap, dbw.rightTmp.TagMap, "NoteID", idChanges)
+			break
+		}
+		switch err := err.(type) {
+		case merger.MergeConflictError:
+			if conflictSolver == "" {
+				mcw.addConflicts(err.Conflicts)
+				return MergeConflictError{}
+			}
+			var resErr error
+			conflictSolution, resErr = merger.AutoResolveConflicts(err.Conflicts, conflictSolver)
+			if resErr != nil {
+				return errors.Wrap(err, "Could not automatically solve conflicts for notes")
+			}
+		default:
+			return errors.Wrap(err, "Could not merge notes")
+		}
+	}
+
+	return nil
+}
+
+// MergeTagMaps merges tagMaps
+func (dbw *DatabaseWrapper) MergeTagMaps() error {
+	var conflictSolution map[string]merger.MergeSolution
+	for {
+		merged, _, err := merger.MergeTagMaps(dbw.leftTmp.TagMap, dbw.rightTmp.TagMap, conflictSolution)
+		if err == nil {
+			dbw.merged.TagMap = merged
+			break
+		}
+
+		return errors.Wrap(err, "Could not merge tagMaps")
+	}
+
+	return nil
+}

--- a/gomobile/MergeConflict.go
+++ b/gomobile/MergeConflict.go
@@ -1,0 +1,157 @@
+package gomobile
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/AndreasSko/go-jwlm/merger"
+)
+
+// MergeConflictError indicates that a conflict happened while merging. It
+// is equivalent to merger.MergeConflictError, but does not contain the
+// actual conflicts to make it compatible with Gomobile.
+type MergeConflictError struct {
+	Err string
+}
+
+func (e MergeConflictError) Error() string {
+	return fmt.Sprintf("There were conflicts while trying to merge %s", e.Err)
+}
+
+// MergeConflictsWrapper wraps mergeConflicts and their solutions
+type MergeConflictsWrapper struct {
+	DBWrapper       *DatabaseWrapper
+	conflicts       map[string]merger.MergeConflict
+	conflictKeys    []string
+	solvedConflicts int
+	solutions       map[string]merger.MergeSolution
+}
+
+// MergeConflict represents two Models that collide. It is equvalent
+// to merger.MergeConflict, but represents the Models as strings
+// to make it compatible with Gomobile.
+type MergeConflict struct {
+	Left  string
+	Right string
+}
+
+// InitDBWrapper initializes the DatabaseWrapper for the MergeConflictsWrapper
+// so the DB is accessible for pretty printing.
+func (mcw *MergeConflictsWrapper) InitDBWrapper(dbw *DatabaseWrapper) {
+	mcw.DBWrapper = dbw
+}
+
+// addConflicts adds the given conflicts to the MergeConflictWrapper
+// and makes sure that the keys are added to conflictsKeys. This
+// makes sure, that the order stays the same. If the conflict already
+// exists, it is skipped.
+func (mcw *MergeConflictsWrapper) addConflicts(conflicts map[string]merger.MergeConflict) {
+	if mcw.conflicts == nil {
+		mcw.conflicts = make(map[string]merger.MergeConflict, len(conflicts))
+	}
+
+	if mcw.conflictKeys == nil {
+		mcw.conflictKeys = make([]string, 0, len(conflicts))
+	}
+
+	for key, value := range conflicts {
+		if _, exists := mcw.conflicts[key]; !exists {
+			mcw.conflicts[key] = value
+			mcw.conflictKeys = append(mcw.conflictKeys, key)
+		}
+	}
+}
+
+// ConflictsLen returns the length of the conflicts map.
+func (mcw *MergeConflictsWrapper) ConflictsLen() int {
+	if mcw.conflicts == nil {
+		return 0
+	}
+
+	return len(mcw.conflicts)
+}
+
+// SolutionsLen returns the length of the solutions slice
+func (mcw *MergeConflictsWrapper) SolutionsLen() int {
+	if mcw.solutions == nil {
+		return 0
+	}
+
+	return len(mcw.solutions)
+}
+
+// GetNextConflictIndex returns the next conflict index, for which
+// the conflict is not solved yet. If there are none left, it returns
+// -1 indicating that all conflicts have been solved.
+func (mcw *MergeConflictsWrapper) GetNextConflictIndex() int {
+	if mcw.solvedConflicts >= len(mcw.conflicts) {
+		return -1
+	}
+
+	return mcw.solvedConflicts
+}
+
+// GetConflict returns the conflict at index
+func (mcw *MergeConflictsWrapper) GetConflict(index int) (*MergeConflict, error) {
+	if mcw.conflicts == nil || mcw.conflictKeys == nil {
+		return nil, errors.New("There are no conflicts")
+	}
+
+	if index >= len(mcw.conflictKeys) {
+		return nil, fmt.Errorf("Conflict with index %d does not exist. Length=%d", index, len(mcw.conflictKeys))
+	}
+	key := mcw.conflictKeys[index]
+
+	if mcw.DBWrapper == nil {
+		mcw.DBWrapper = &DatabaseWrapper{merged: nil}
+	}
+
+	return &MergeConflict{
+		Left:  mcw.conflicts[key].Left.PrettyPrint(mcw.DBWrapper.merged),
+		Right: mcw.conflicts[key].Right.PrettyPrint(mcw.DBWrapper.merged),
+	}, nil
+}
+
+// SolveConflict solves a mergeConflict by choosing the given side at index.
+// Index must be less or equal to GetNextConflictIndex(), to ensure that
+// conflicts are solved in order and none are missed.
+func (mcw *MergeConflictsWrapper) SolveConflict(index int, side string) error {
+	if mcw.conflicts == nil || mcw.conflictKeys == nil {
+		return errors.New("There are no conflicts")
+	}
+	if index >= len(mcw.conflictKeys) {
+		return fmt.Errorf("Conflict with index %d does not exist. Length=%d", index, len(mcw.conflictKeys))
+	}
+	if mcw.GetNextConflictIndex() != -1 && mcw.GetNextConflictIndex() < index {
+		return fmt.Errorf("Index is higher than NextConflictIndex: %d > %d. The conflicts before have to be solved first",
+			index, mcw.GetNextConflictIndex())
+	}
+
+	if mcw.solutions == nil {
+		mcw.solutions = make(map[string]merger.MergeSolution, len(mcw.conflictKeys))
+	}
+
+	key := mcw.conflictKeys[index]
+	switch side {
+	case "leftSide":
+		mcw.solutions[key] = merger.MergeSolution{
+			Side:      merger.LeftSide,
+			Solution:  mcw.conflicts[key].Left,
+			Discarded: mcw.conflicts[key].Right,
+		}
+	case "rightSide":
+		mcw.solutions[key] = merger.MergeSolution{
+			Side:      merger.RightSide,
+			Solution:  mcw.conflicts[key].Right,
+			Discarded: mcw.conflicts[key].Left,
+		}
+	default:
+		return fmt.Errorf("Side %s is not valid", side)
+	}
+
+	if mcw.GetNextConflictIndex() == index {
+		mcw.solvedConflicts++
+	}
+
+	return nil
+}

--- a/gomobile/MergeConflict_test.go
+++ b/gomobile/MergeConflict_test.go
@@ -1,0 +1,224 @@
+package gomobile
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/AndreasSko/go-jwlm/merger"
+	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeConflictsWrapper_InitDBWrapper(t *testing.T) {
+	dbw := &DatabaseWrapper{
+		left: &model.Database{},
+	}
+
+	mcw := MergeConflictsWrapper{}
+	mcw.InitDBWrapper(dbw)
+
+	assert.Same(t, dbw, mcw.DBWrapper)
+}
+
+func TestMergeConflictsWrapper_addConflicts(t *testing.T) {
+	conflicts := map[string]merger.MergeConflict{
+		"1": {
+			Left: &model.Bookmark{
+				Title: "1Left",
+			},
+			Right: &model.Bookmark{
+				Title: "1Right",
+			},
+		},
+		"2": {
+			Left: &model.Tag{
+				Name: "2Left",
+			},
+			Right: &model.Tag{
+				Name: "2Right",
+			},
+		},
+	}
+
+	mcw := MergeConflictsWrapper{}
+	mcw.addConflicts(conflicts)
+	sort.Strings(mcw.conflictKeys)
+	assert.Equal(t, conflicts, mcw.conflicts)
+	assert.Equal(t, []string{"1", "2"}, mcw.conflictKeys)
+
+	conflicts["3"] = merger.MergeConflict{
+		Left: &model.Tag{
+			Name: "2Left",
+		},
+		Right: &model.Tag{
+			Name: "2Right",
+		},
+	}
+
+	mcw.addConflicts(conflicts)
+	assert.Equal(t, conflicts, mcw.conflicts)
+	assert.Equal(t, []string{"1", "2", "3"}, mcw.conflictKeys)
+}
+
+func TestMergeConflictsWrapper_ConflictsLen(t *testing.T) {
+	mcw := MergeConflictsWrapper{}
+	assert.Equal(t, 0, mcw.ConflictsLen())
+
+	mcw.conflicts = map[string]merger.MergeConflict{"1": {}, "2": {}, "3": {}}
+	assert.Equal(t, 3, mcw.ConflictsLen())
+}
+
+func TestMergeConflictsWrapper_SolutionsLen(t *testing.T) {
+	mcw := MergeConflictsWrapper{}
+	assert.Equal(t, 0, mcw.SolutionsLen())
+
+	mcw.solutions = map[string]merger.MergeSolution{"1": {}, "2": {}, "3": {}}
+	assert.Equal(t, 3, mcw.SolutionsLen())
+}
+
+func TestMergeConflictsWrapper_GetNextConflictIndex(t *testing.T) {
+	conflicts := map[string]merger.MergeConflict{
+		"1": {
+			Left: &model.Bookmark{
+				Title: "1Left",
+			},
+			Right: &model.Bookmark{
+				Title: "1Right",
+			},
+		},
+		"2": {
+			Left: &model.Tag{
+				Name: "2Left",
+			},
+			Right: &model.Tag{
+				Name: "2Right",
+			},
+		},
+	}
+
+	mcw := MergeConflictsWrapper{}
+	mcw.addConflicts(conflicts)
+
+	assert.Equal(t, 0, mcw.GetNextConflictIndex())
+	assert.Error(t, mcw.SolveConflict(1, "leftSide"))
+	assert.NoError(t, mcw.SolveConflict(0, "leftSide"))
+	assert.NoError(t, mcw.SolveConflict(0, "leftSide")) // Solving the same conflict should not increase counter
+	assert.Equal(t, 1, mcw.GetNextConflictIndex())
+	assert.NoError(t, mcw.SolveConflict(1, "leftSide"))
+	assert.Equal(t, -1, mcw.GetNextConflictIndex())
+}
+
+func TestMergeConflictsWrapper_GetConflict(t *testing.T) {
+	mcw := MergeConflictsWrapper{
+		conflicts: map[string]merger.MergeConflict{
+			"1": {
+				Left: &model.Bookmark{
+					Title: "1Left",
+				},
+				Right: &model.Bookmark{
+					Title: "1Right",
+				},
+			},
+			"2": {
+				Left: &model.Tag{
+					Name: "2Left",
+				},
+				Right: &model.Tag{
+					Name: "2Right",
+				},
+			},
+		},
+		conflictKeys: []string{"1", "2"},
+	}
+
+	conflict, err := mcw.GetConflict(0)
+	assert.NoError(t, err)
+	assert.Equal(t, mcw.conflicts["1"].Left.PrettyPrint(nil), conflict.Left)
+	assert.Equal(t, mcw.conflicts["1"].Right.PrettyPrint(nil), conflict.Right)
+
+	conflict, err = mcw.GetConflict(1)
+	assert.NoError(t, err)
+	assert.Equal(t, mcw.conflicts["2"].Left.PrettyPrint(nil), conflict.Left)
+	assert.Equal(t, mcw.conflicts["2"].Right.PrettyPrint(nil), conflict.Right)
+
+	_, err = mcw.GetConflict(3)
+	assert.Error(t, err)
+
+	mcw.conflicts = nil
+	_, err = mcw.GetConflict(1)
+	assert.Error(t, err)
+}
+
+func TestMergeConflictsWrapper_SolveConflict(t *testing.T) {
+	mcw := MergeConflictsWrapper{}
+	assert.EqualError(t, mcw.SolveConflict(0, "leftSide"), "There are no conflicts")
+
+	mcw = MergeConflictsWrapper{
+		conflicts: map[string]merger.MergeConflict{
+			"1": {
+				Left: &model.Bookmark{
+					Title: "1Left",
+				},
+				Right: &model.Bookmark{
+					Title: "1Right",
+				},
+			},
+			"2": {
+				Left: &model.Tag{
+					Name: "2Left",
+				},
+				Right: &model.Tag{
+					Name: "2Right",
+				},
+			},
+			"3": {
+				Left: &model.Tag{
+					Name: "3Left",
+				},
+				Right: &model.Tag{
+					Name: "3Right",
+				},
+			},
+		},
+		conflictKeys: []string{"1", "2", "3"},
+	}
+	assert.EqualError(t, mcw.SolveConflict(3, "leftSide"), "Conflict with index 3 does not exist. Length=3")
+	assert.EqualError(t, mcw.SolveConflict(1, "leftSide"), "Index is higher than NextConflictIndex: 1 > 0. The conflicts before have to be solved first")
+	assert.EqualError(t, mcw.SolveConflict(0, "wrongSide"), "Side wrongSide is not valid")
+
+	assert.NoError(t, mcw.SolveConflict(0, "rightSide"))
+	assert.Equal(t,
+		merger.MergeSolution{
+			Side:      merger.RightSide,
+			Solution:  mcw.conflicts["1"].Right,
+			Discarded: mcw.conflicts["1"].Left,
+		},
+		mcw.solutions["1"])
+	assert.Equal(t, 1, mcw.GetNextConflictIndex())
+	assert.NoError(t, mcw.SolveConflict(0, "rightSide"))
+	assert.Equal(t, 1, mcw.GetNextConflictIndex())
+
+	assert.NoError(t, mcw.SolveConflict(1, "leftSide"))
+	assert.Equal(t,
+		merger.MergeSolution{
+			Side:      merger.LeftSide,
+			Solution:  mcw.conflicts["2"].Left,
+			Discarded: mcw.conflicts["2"].Right,
+		},
+		mcw.solutions["2"])
+	assert.Equal(t, 2, mcw.GetNextConflictIndex())
+
+	assert.NoError(t, mcw.SolveConflict(2, "leftSide"))
+	assert.Equal(t, -1, mcw.GetNextConflictIndex())
+
+	// Change previous solution to different one
+	assert.NoError(t, mcw.SolveConflict(0, "leftSide"))
+	assert.Equal(t,
+		merger.MergeSolution{
+			Side:      merger.LeftSide,
+			Solution:  mcw.conflicts["1"].Left,
+			Discarded: mcw.conflicts["1"].Right,
+		},
+		mcw.solutions["1"])
+	assert.Equal(t, -1, mcw.GetNextConflictIndex())
+}

--- a/gomobile/Merge_test.go
+++ b/gomobile/Merge_test.go
@@ -1,0 +1,764 @@
+package gomobile
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/tj/assert"
+)
+
+// These tests are more ore less copied from cmd/merge_test.go
+
+// Merge against empty DB and see if result is still the same
+func Test_MergeWithEmpty(t *testing.T) {
+	dbw := DatabaseWrapper{
+		left:  model.MakeDatabaseCopy(leftDB),
+		right: model.MakeDatabaseCopy(emptyDB),
+	}
+	dbw.Init()
+
+	mcw := &MergeConflictsWrapper{}
+
+	assert.NoError(t, dbw.MergeLocations())
+	assert.NoError(t, dbw.MergeBookmarks("", mcw))
+	assert.NoError(t, dbw.MergeTags())
+	assert.NoError(t, dbw.MergeUserMarkAndBlockRange("", mcw))
+	assert.NoError(t, dbw.MergeNotes("", mcw))
+	assert.NoError(t, dbw.MergeTagMaps())
+
+	assert.True(t, dbw.left.Equals(dbw.merged))
+}
+
+// Merge while selecting all right
+func Test_MergeAllRight(t *testing.T) {
+	dbw := DatabaseWrapper{
+		left:  model.MakeDatabaseCopy(leftDB),
+		right: model.MakeDatabaseCopy(rightDB),
+	}
+	dbw.Init()
+
+	mcw := &MergeConflictsWrapper{}
+
+	assert.NoError(t, dbw.MergeLocations())
+	assert.Error(t, dbw.MergeBookmarks("", mcw))
+	selectSameSide(mcw, "rightSide")
+
+	dbw.Init()
+	assert.NoError(t, dbw.MergeLocations())
+	assert.NoError(t, dbw.MergeBookmarks("", mcw))
+	assert.NoError(t, dbw.MergeTags())
+	assert.Error(t, dbw.MergeUserMarkAndBlockRange("", mcw))
+	selectSameSide(mcw, "rightSide")
+
+	dbw.Init()
+	assert.NoError(t, dbw.MergeLocations())
+	assert.NoError(t, dbw.MergeBookmarks("", mcw))
+	assert.NoError(t, dbw.MergeTags())
+	assert.NoError(t, dbw.MergeUserMarkAndBlockRange("", mcw))
+	assert.Error(t, dbw.MergeNotes("", mcw))
+	selectSameSide(mcw, "rightSide")
+
+	dbw.Init()
+	assert.NoError(t, dbw.MergeLocations())
+	assert.NoError(t, dbw.MergeBookmarks("", mcw))
+	assert.NoError(t, dbw.MergeTags())
+	assert.NoError(t, dbw.MergeUserMarkAndBlockRange("", mcw))
+	assert.NoError(t, dbw.MergeNotes("", mcw))
+	assert.NoError(t, dbw.MergeTagMaps())
+
+	assert.True(t, mergedAllRightDB.Equals(dbw.merged))
+}
+
+// Merge while selecting all right
+func Test_MergeAllLeft(t *testing.T) {
+	dbw := DatabaseWrapper{
+		left:  model.MakeDatabaseCopy(leftDB),
+		right: model.MakeDatabaseCopy(rightDB),
+	}
+	dbw.Init()
+
+	mcw := &MergeConflictsWrapper{}
+
+	assert.NoError(t, dbw.MergeLocations())
+	assert.Error(t, dbw.MergeBookmarks("", mcw))
+	selectSameSide(mcw, "leftSide")
+
+	dbw.Init()
+	assert.NoError(t, dbw.MergeLocations())
+	assert.NoError(t, dbw.MergeBookmarks("", mcw))
+	assert.NoError(t, dbw.MergeTags())
+	assert.Error(t, dbw.MergeUserMarkAndBlockRange("", mcw))
+	selectSameSide(mcw, "leftSide")
+
+	dbw.Init()
+	assert.NoError(t, dbw.MergeLocations())
+	assert.NoError(t, dbw.MergeBookmarks("", mcw))
+	assert.NoError(t, dbw.MergeTags())
+	assert.NoError(t, dbw.MergeUserMarkAndBlockRange("", mcw))
+	assert.Error(t, dbw.MergeNotes("", mcw))
+	selectSameSide(mcw, "leftSide")
+
+	dbw.Init()
+	assert.NoError(t, dbw.MergeLocations())
+	assert.NoError(t, dbw.MergeBookmarks("", mcw))
+	assert.NoError(t, dbw.MergeTags())
+	assert.NoError(t, dbw.MergeUserMarkAndBlockRange("", mcw))
+	assert.NoError(t, dbw.MergeNotes("", mcw))
+	assert.NoError(t, dbw.MergeTagMaps())
+
+	assert.True(t, mergedAllLeftDB.Equals(dbw.merged))
+}
+
+// Merge with auto resolution: chooseRight for Bookmarks & Markings,
+// chooseNewest for Notes
+func Test_MergeWithAutoresolution(t *testing.T) {
+	dbw := DatabaseWrapper{
+		left:  model.MakeDatabaseCopy(leftDB),
+		right: model.MakeDatabaseCopy(rightDB),
+	}
+	dbw.Init()
+
+	mcw := &MergeConflictsWrapper{}
+
+	assert.NoError(t, dbw.MergeLocations())
+	assert.NoError(t, dbw.MergeBookmarks("chooseRight", mcw))
+	assert.NoError(t, dbw.MergeTags())
+	assert.NoError(t, dbw.MergeUserMarkAndBlockRange("chooseRight", mcw))
+	assert.NoError(t, dbw.MergeNotes("chooseNewest", mcw))
+	assert.NoError(t, dbw.MergeTagMaps())
+
+	assert.True(t, mergedAllRightDB.Equals(dbw.merged))
+}
+
+func selectSameSide(mcw *MergeConflictsWrapper, side string) {
+	for i := mcw.GetNextConflictIndex(); i != -1; i = mcw.GetNextConflictIndex() {
+		mcw.SolveConflict(i, side)
+	}
+}
+
+var emptyDB = &model.Database{}
+
+var leftDB = &model.Database{
+	BlockRange: []*model.BlockRange{
+		nil,
+		{
+			BlockRangeID: 1,
+			BlockType:    2,
+			Identifier:   1,
+			StartToken:   sql.NullInt32{0, true},
+			EndToken:     sql.NullInt32{7, true},
+			UserMarkID:   1,
+		},
+	},
+	Bookmark: []*model.Bookmark{
+		nil,
+		{
+			BookmarkID:            1,
+			LocationID:            1,
+			PublicationLocationID: 2,
+			Title:                 "1. Mose 1:1",
+			Snippet:               sql.NullString{"1 Am Anfang erschuf Gott Himmel und Erde.", true},
+			BlockType:             2,
+			BlockIdentifier:       sql.NullInt32{1, true},
+		},
+	},
+	Location: []*model.Location{
+		nil,
+		{
+			LocationID:    1,
+			BookNumber:    sql.NullInt32{1, true},
+			ChapterNumber: sql.NullInt32{1, true},
+			KeySymbol:     sql.NullString{"nwtsty", true},
+			MepsLanguage:  2,
+			LocationType:  0,
+			Title:         sql.NullString{"1. Mose 1", true},
+		},
+		{
+			LocationID:   2,
+			KeySymbol:    sql.NullString{"nwtsty", true},
+			MepsLanguage: 2,
+			LocationType: 1,
+		},
+	},
+	Note: []*model.Note{
+		nil,
+		{
+			NoteID:          1,
+			GUID:            "92B192B4-B0B9-49B2-949F-7A8BA6406AF4",
+			UserMarkID:      sql.NullInt32{1, true},
+			LocationID:      sql.NullInt32{1, true},
+			Title:           sql.NullString{"Am Anfang erschuf Gott Himmel und Erde.", true},
+			Content:         sql.NullString{"📝 for left version", true},
+			LastModified:    "2020-09-15T13:45:38+00:00",
+			BlockType:       2,
+			BlockIdentifier: sql.NullInt32{1, true},
+		},
+		{
+			NoteID:       2,
+			GUID:         "E36B34A0-B70F-4590-9D69-5887AB65A6D5",
+			Title:        sql.NullString{"Same Note", true},
+			Content:      sql.NullString{"This note is also available on the other side", true},
+			LastModified: "2020-09-15T13:52:25+00:00",
+			BlockType:    0,
+		},
+	},
+	Tag: []*model.Tag{
+		nil,
+		{
+			TagID:   1,
+			TagType: 0,
+			Name:    "Favorite",
+		},
+		{
+			TagID:   2,
+			TagType: 1,
+			Name:    "Left",
+		},
+		{
+			TagID:   3,
+			TagType: 1,
+			Name:    "Same",
+		},
+	},
+	TagMap: []*model.TagMap{
+		nil,
+		{
+			TagMapID: 1,
+			NoteID:   sql.NullInt32{1, true},
+			TagID:    2,
+			Position: 0,
+		},
+		{
+			TagMapID: 2,
+			NoteID:   sql.NullInt32{2, true},
+			TagID:    3,
+			Position: 0,
+		},
+	},
+	UserMark: []*model.UserMark{
+		nil,
+		{
+			UserMarkID:   1,
+			ColorIndex:   1,
+			LocationID:   1,
+			StyleIndex:   0,
+			UserMarkGUID: "0D5523D9-F784-4B08-A86D-D517F4EB17DE",
+			Version:      1,
+		},
+	},
+}
+
+var rightDB = &model.Database{
+	BlockRange: []*model.BlockRange{
+		nil,
+		{
+			BlockRangeID: 1,
+			BlockType:    2,
+			Identifier:   1,
+			StartToken:   sql.NullInt32{0, true},
+			EndToken:     sql.NullInt32{15, true},
+			UserMarkID:   1,
+		},
+		{
+			BlockRangeID: 2,
+			BlockType:    2,
+			Identifier:   1,
+			StartToken:   sql.NullInt32{0, true},
+			EndToken:     sql.NullInt32{7, true},
+			UserMarkID:   2,
+		},
+		{
+			BlockRangeID: 3,
+			BlockType:    2,
+			Identifier:   2,
+			StartToken:   sql.NullInt32{0, true},
+			EndToken:     sql.NullInt32{12, true},
+			UserMarkID:   2,
+		},
+		{
+			BlockRangeID: 4,
+			BlockType:    2,
+			Identifier:   2,
+			StartToken:   sql.NullInt32{13, true},
+			EndToken:     sql.NullInt32{26, true},
+			UserMarkID:   3,
+		},
+	},
+	Bookmark: []*model.Bookmark{
+		nil,
+		{
+			BookmarkID:            1,
+			LocationID:            1,
+			PublicationLocationID: 2,
+			Title:                 "1. Mose 2:1",
+			Snippet:               sql.NullString{"2 So wurde die Erschaffung von Himmel und Erde und allem, was dazugehört, beendet. ", true},
+			BlockType:             2,
+			BlockIdentifier:       sql.NullInt32{1, true},
+		},
+	},
+	Location: []*model.Location{
+		nil,
+		{
+			LocationID:    1,
+			BookNumber:    sql.NullInt32{1, true},
+			ChapterNumber: sql.NullInt32{2, true},
+			KeySymbol:     sql.NullString{"nwtsty", true},
+			MepsLanguage:  2,
+			LocationType:  0,
+			Title:         sql.NullString{"1. Mose 2", true},
+		},
+		{
+			LocationID:   2,
+			KeySymbol:    sql.NullString{"nwtsty", true},
+			MepsLanguage: 2,
+			LocationType: 1,
+		},
+		{
+			LocationID:    3,
+			BookNumber:    sql.NullInt32{1, true},
+			ChapterNumber: sql.NullInt32{1, true},
+			KeySymbol:     sql.NullString{"nwtsty", true},
+			MepsLanguage:  2,
+			LocationType:  0,
+			Title:         sql.NullString{"1. Mose 1", true},
+		},
+	},
+	Note: []*model.Note{
+		nil,
+		{
+			NoteID:          1,
+			GUID:            "DE4A2CDA-9892-4A94-AF4B-22EBE05A05CA",
+			UserMarkID:      sql.NullInt32{1, true},
+			LocationID:      sql.NullInt32{1, true},
+			Title:           sql.NullString{"So wurde die Erschaffung von Himmel und Erde und allem, was dazugehört, beendet.", true},
+			Content:         sql.NullString{"📝 on the right side", true},
+			LastModified:    "2020-09-15T13:47:56+00:00",
+			BlockType:       2,
+			BlockIdentifier: sql.NullInt32{1, true},
+		},
+		{
+			NoteID:       2,
+			GUID:         "E36B34A0-B70F-4590-9D69-5887AB65A6D5",
+			Title:        sql.NullString{"Same Note", true},
+			Content:      sql.NullString{"This note is also available on the other side. Though this one is newer 😏", true},
+			LastModified: "2020-09-20T13:52:25+00:00",
+			BlockType:    0,
+		},
+	},
+	Tag: []*model.Tag{
+		nil,
+		{
+			TagID:   1,
+			TagType: 0,
+			Name:    "Favorite",
+		},
+		{
+			TagID:   2,
+			TagType: 1,
+			Name:    "Right",
+		},
+		{
+			TagID:   3,
+			TagType: 1,
+			Name:    "Same",
+		},
+	},
+	TagMap: []*model.TagMap{
+		nil,
+		{
+			TagMapID: 1,
+			NoteID:   sql.NullInt32{1, true},
+			TagID:    2,
+			Position: 0,
+		},
+		{
+			TagMapID: 2,
+			NoteID:   sql.NullInt32{2, true},
+			TagID:    3,
+			// Should normally be 0, but changed it to 1 to detect
+			// if merger recognizes that its still the same entry,
+			// just with a different position
+			Position: 1,
+		},
+	},
+	UserMark: []*model.UserMark{
+		nil,
+		{
+			UserMarkID:   1,
+			ColorIndex:   1,
+			LocationID:   1,
+			StyleIndex:   0,
+			UserMarkGUID: "54C23825-AC1E-4890-8041-92B39C5E4B17",
+			Version:      1,
+		},
+		{
+			UserMarkID:   2,
+			ColorIndex:   1,
+			LocationID:   3,
+			StyleIndex:   0,
+			UserMarkGUID: "A098D2B0-7613-4676-9E96-442755105D9A",
+		},
+		{
+			UserMarkID:   3,
+			ColorIndex:   1,
+			LocationID:   3,
+			StyleIndex:   0,
+			UserMarkGUID: "A86DECC8-69B1-4A43-A3A1-F1CA7B8E8388",
+			Version:      1,
+		},
+	},
+}
+
+var mergedAllLeftDB = model.Database{
+	BlockRange: []*model.BlockRange{
+		nil,
+		{
+			BlockRangeID: 1,
+			BlockType:    2,
+			Identifier:   1,
+			StartToken:   sql.NullInt32{0, true},
+			EndToken:     sql.NullInt32{7, true},
+			UserMarkID:   1,
+		},
+		{
+			BlockRangeID: 2,
+			BlockType:    2,
+			Identifier:   1,
+			StartToken:   sql.NullInt32{0, true},
+			EndToken:     sql.NullInt32{15, true},
+			UserMarkID:   2,
+		},
+		{
+			BlockRangeID: 3,
+			BlockType:    2,
+			Identifier:   2,
+			StartToken:   sql.NullInt32{13, true},
+			EndToken:     sql.NullInt32{26, true},
+			UserMarkID:   3,
+		},
+	},
+	Bookmark: []*model.Bookmark{
+		nil,
+		{
+			BookmarkID:            1,
+			LocationID:            1,
+			PublicationLocationID: 2,
+			Title:                 "1. Mose 1:1",
+			Snippet:               sql.NullString{"1 Am Anfang erschuf Gott Himmel und Erde.", true},
+			BlockType:             2,
+			BlockIdentifier:       sql.NullInt32{1, true},
+		},
+	},
+	Location: []*model.Location{
+		nil,
+		{
+			LocationID:    1,
+			BookNumber:    sql.NullInt32{1, true},
+			ChapterNumber: sql.NullInt32{1, true},
+			KeySymbol:     sql.NullString{"nwtsty", true},
+			MepsLanguage:  2,
+			LocationType:  0,
+			Title:         sql.NullString{"1. Mose 1", true},
+		},
+		{
+			LocationID:   2,
+			KeySymbol:    sql.NullString{"nwtsty", true},
+			MepsLanguage: 2,
+			LocationType: 1,
+		},
+		{
+			LocationID:    3,
+			BookNumber:    sql.NullInt32{1, true},
+			ChapterNumber: sql.NullInt32{2, true},
+			KeySymbol:     sql.NullString{"nwtsty", true},
+			MepsLanguage:  2,
+			LocationType:  0,
+			Title:         sql.NullString{"1. Mose 2", true},
+		},
+	},
+	Note: []*model.Note{
+		nil,
+		{
+			NoteID:          1,
+			GUID:            "92B192B4-B0B9-49B2-949F-7A8BA6406AF4",
+			UserMarkID:      sql.NullInt32{1, true},
+			LocationID:      sql.NullInt32{1, true},
+			Title:           sql.NullString{"Am Anfang erschuf Gott Himmel und Erde.", true},
+			Content:         sql.NullString{"📝 for left version", true},
+			LastModified:    "2020-09-15T13:45:38+00:00",
+			BlockType:       2,
+			BlockIdentifier: sql.NullInt32{1, true},
+		},
+		{
+			NoteID:       2,
+			GUID:         "E36B34A0-B70F-4590-9D69-5887AB65A6D5",
+			Title:        sql.NullString{"Same Note", true},
+			Content:      sql.NullString{"This note is also available on the other side", true},
+			LastModified: "2020-09-15T13:52:25+00:00",
+			BlockType:    0,
+		},
+		{
+			NoteID:          3,
+			GUID:            "DE4A2CDA-9892-4A94-AF4B-22EBE05A05CA",
+			UserMarkID:      sql.NullInt32{1, true},
+			LocationID:      sql.NullInt32{1, true},
+			Title:           sql.NullString{"So wurde die Erschaffung von Himmel und Erde und allem, was dazugehört, beendet.", true},
+			Content:         sql.NullString{"📝 on the right side", true},
+			LastModified:    "2020-09-15T13:47:56+00:00",
+			BlockType:       2,
+			BlockIdentifier: sql.NullInt32{1, true},
+		},
+	},
+	Tag: []*model.Tag{
+		nil,
+		{
+			TagID:   1,
+			TagType: 0,
+			Name:    "Favorite",
+		},
+		{
+			TagID:   2,
+			TagType: 1,
+			Name:    "Left",
+		},
+		{
+			TagID:   3,
+			TagType: 1,
+			Name:    "Same",
+		},
+		{
+			TagID:   4,
+			TagType: 1,
+			Name:    "Right",
+		},
+	},
+	TagMap: []*model.TagMap{
+		nil,
+		{
+			TagMapID: 1,
+			NoteID:   sql.NullInt32{1, true},
+			TagID:    2,
+			Position: 0,
+		},
+		{
+			TagMapID: 2,
+			NoteID:   sql.NullInt32{2, true},
+			TagID:    3,
+			Position: 0,
+		},
+		{
+			TagMapID: 2,
+			NoteID:   sql.NullInt32{3, true},
+			TagID:    4,
+			Position: 0,
+		},
+	},
+	UserMark: []*model.UserMark{
+		nil,
+		{
+			UserMarkID:   1,
+			ColorIndex:   1,
+			LocationID:   1,
+			StyleIndex:   0,
+			UserMarkGUID: "0D5523D9-F784-4B08-A86D-D517F4EB17DE",
+			Version:      1,
+		},
+		{
+			UserMarkID:   2,
+			ColorIndex:   1,
+			LocationID:   3,
+			StyleIndex:   0,
+			UserMarkGUID: "54C23825-AC1E-4890-8041-92B39C5E4B17",
+			Version:      1,
+		},
+		{
+			UserMarkID:   3,
+			ColorIndex:   1,
+			LocationID:   1,
+			StyleIndex:   0,
+			UserMarkGUID: "A86DECC-69B1-4A43-A3A1-F1CA7B8E8388",
+			Version:      1,
+		},
+	},
+}
+
+var mergedAllRightDB = model.Database{
+	BlockRange: []*model.BlockRange{
+		nil,
+		{
+			BlockRangeID: 1,
+			BlockType:    2,
+			Identifier:   1,
+			StartToken:   sql.NullInt32{0, true},
+			EndToken:     sql.NullInt32{15, true},
+			UserMarkID:   1,
+		},
+		{
+			BlockRangeID: 2,
+			BlockType:    2,
+			Identifier:   1,
+			StartToken:   sql.NullInt32{0, true},
+			EndToken:     sql.NullInt32{7, true},
+			UserMarkID:   2,
+		},
+		{
+			BlockRangeID: 3,
+			BlockType:    2,
+			Identifier:   2,
+			StartToken:   sql.NullInt32{0, true},
+			EndToken:     sql.NullInt32{12, true},
+			UserMarkID:   2,
+		},
+		{
+			BlockRangeID: 4,
+			BlockType:    2,
+			Identifier:   2,
+			StartToken:   sql.NullInt32{13, true},
+			EndToken:     sql.NullInt32{26, true},
+			UserMarkID:   3,
+		},
+	},
+	Bookmark: []*model.Bookmark{
+		nil,
+		{
+			BookmarkID:            1,
+			LocationID:            3,
+			PublicationLocationID: 2,
+			Title:                 "1. Mose 2:1",
+			Snippet:               sql.NullString{"2 So wurde die Erschaffung von Himmel und Erde und allem, was dazugehört, beendet. ", true},
+			BlockType:             2,
+			BlockIdentifier:       sql.NullInt32{1, true},
+		},
+	},
+	Location: []*model.Location{
+		nil,
+		{
+			LocationID:    1,
+			BookNumber:    sql.NullInt32{1, true},
+			ChapterNumber: sql.NullInt32{1, true},
+			KeySymbol:     sql.NullString{"nwtsty", true},
+			MepsLanguage:  2,
+			LocationType:  0,
+			Title:         sql.NullString{"1. Mose 1", true},
+		},
+		{
+			LocationID:   2,
+			KeySymbol:    sql.NullString{"nwtsty", true},
+			MepsLanguage: 2,
+			LocationType: 1,
+		},
+		{
+			LocationID:    3,
+			BookNumber:    sql.NullInt32{1, true},
+			ChapterNumber: sql.NullInt32{2, true},
+			KeySymbol:     sql.NullString{"nwtsty", true},
+			MepsLanguage:  2,
+			LocationType:  0,
+			Title:         sql.NullString{"1. Mose 2", true},
+		},
+	},
+	Note: []*model.Note{
+		nil,
+		{
+			NoteID:          1,
+			GUID:            "92B192B4-B0B9-49B2-949F-7A8BA6406AF4",
+			UserMarkID:      sql.NullInt32{1, true},
+			LocationID:      sql.NullInt32{1, true},
+			Title:           sql.NullString{"Am Anfang erschuf Gott Himmel und Erde.", true},
+			Content:         sql.NullString{"📝 for left version", true},
+			LastModified:    "2020-09-15T13:45:38+00:00",
+			BlockType:       2,
+			BlockIdentifier: sql.NullInt32{1, true},
+		},
+		{
+			NoteID:       2,
+			GUID:         "E36B34A0-B70F-4590-9D69-5887AB65A6D5",
+			Title:        sql.NullString{"Same Note", true},
+			Content:      sql.NullString{"This note is also available on the other side. Though this one is newer 😏", true},
+			LastModified: "2020-09-20T13:52:25+00:00",
+			BlockType:    0,
+		},
+		{
+			NoteID:          3,
+			GUID:            "DE4A2CDA-9892-4A94-AF4B-22EBE05A05CA",
+			UserMarkID:      sql.NullInt32{1, true},
+			LocationID:      sql.NullInt32{1, true},
+			Title:           sql.NullString{"So wurde die Erschaffung von Himmel und Erde und allem, was dazugehört, beendet.", true},
+			Content:         sql.NullString{"📝 on the right side", true},
+			LastModified:    "2020-09-15T13:47:56+00:00",
+			BlockType:       2,
+			BlockIdentifier: sql.NullInt32{1, true},
+		},
+	},
+	Tag: []*model.Tag{
+		nil,
+		{
+			TagID:   1,
+			TagType: 0,
+			Name:    "Favorite",
+		},
+		{
+			TagID:   2,
+			TagType: 1,
+			Name:    "Left",
+		},
+		{
+			TagID:   3,
+			TagType: 1,
+			Name:    "Same",
+		},
+		{
+			TagID:   4,
+			TagType: 1,
+			Name:    "Right",
+		},
+	},
+	TagMap: []*model.TagMap{
+		nil,
+		{
+			TagMapID: 1,
+			NoteID:   sql.NullInt32{1, true},
+			TagID:    2,
+			Position: 0,
+		},
+		{
+			TagMapID: 2,
+			NoteID:   sql.NullInt32{2, true},
+			TagID:    3,
+			Position: 0,
+		},
+		{
+			TagMapID: 1,
+			NoteID:   sql.NullInt32{3, true},
+			TagID:    4,
+			Position: 0,
+		},
+	},
+	UserMark: []*model.UserMark{
+		nil,
+		{
+			UserMarkID:   1,
+			ColorIndex:   1,
+			LocationID:   3, // 1. Mose 2
+			StyleIndex:   0,
+			UserMarkGUID: "54C23825-AC1E-4890-8041-92B39C5E4B17",
+			Version:      1,
+		},
+		{
+			UserMarkID:   2,
+			ColorIndex:   1,
+			LocationID:   1, // 1. Mose 1
+			StyleIndex:   0,
+			UserMarkGUID: "A098D2B0-7613-4676-9E96-442755105D9A",
+		},
+		{
+			UserMarkID:   3,
+			ColorIndex:   1,
+			LocationID:   1, // 1. Mose 1
+			StyleIndex:   0,
+			UserMarkGUID: "A86DECC8-69B1-4A43-A3A1-F1CA7B8E8388",
+			Version:      1,
+		},
+	},
+}

--- a/gomobile/Stats.go
+++ b/gomobile/Stats.go
@@ -1,0 +1,46 @@
+package gomobile
+
+import "github.com/AndreasSko/go-jwlm/model"
+
+// DatabaseStats represents the rough number of entries
+// within a Database{} by defining it as the length
+// of the slices.
+type DatabaseStats struct {
+	BlockRange int
+	Bookmark   int
+	Location   int
+	Note       int
+	Tag        int
+	TagMap     int
+	UserMark   int
+}
+
+// Stats generates a DatabaseStats for the given mergeSide
+func (dbw *DatabaseWrapper) Stats(side string) *DatabaseStats {
+	var db *model.Database
+
+	switch side {
+	case "leftSide":
+		db = dbw.left
+	case "rightSide":
+		db = dbw.right
+	case "mergeSide":
+		db = dbw.merged
+	default:
+		db = nil
+	}
+
+	if db == nil {
+		return &DatabaseStats{}
+	}
+
+	return &DatabaseStats{
+		BlockRange: len(db.BlockRange),
+		Bookmark:   len(db.Bookmark),
+		Location:   len(db.Location),
+		Note:       len(db.Note),
+		Tag:        len(db.Tag),
+		TagMap:     len(db.TagMap),
+		UserMark:   len(db.UserMark),
+	}
+}

--- a/gomobile/Stats_test.go
+++ b/gomobile/Stats_test.go
@@ -1,0 +1,40 @@
+package gomobile
+
+import (
+	"testing"
+
+	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDatabaseWrapper_Stats(t *testing.T) {
+	db := &model.Database{
+		BlockRange: []*model.BlockRange{nil},
+		Bookmark:   []*model.Bookmark{nil, nil},
+		Location:   []*model.Location{nil, nil, nil},
+		Note:       []*model.Note{nil, nil, nil, nil},
+		Tag:        []*model.Tag{nil, nil, nil, nil, nil},
+		TagMap:     []*model.TagMap{nil, nil, nil, nil, nil, nil},
+		UserMark:   []*model.UserMark{nil, nil, nil, nil, nil, nil, nil},
+	}
+	dbw := &DatabaseWrapper{
+		left:   db,
+		right:  db,
+		merged: db,
+	}
+
+	expected := &DatabaseStats{
+		BlockRange: 1,
+		Bookmark:   2,
+		Location:   3,
+		Note:       4,
+		Tag:        5,
+		TagMap:     6,
+		UserMark:   7,
+	}
+
+	assert.Equal(t, expected, dbw.Stats("leftSide"))
+	assert.Equal(t, expected, dbw.Stats("rightSide"))
+	assert.Equal(t, expected, dbw.Stats("mergeSide"))
+	assert.Equal(t, &DatabaseStats{}, dbw.Stats("wrongSide"))
+}

--- a/merger/MergeConflictSolver.go
+++ b/merger/MergeConflictSolver.go
@@ -9,8 +9,7 @@ import (
 // MergeConflictSolver describes a function that is able to handle mergeConflicts semi-automatic
 type MergeConflictSolver func(map[string]MergeConflict) (map[string]MergeSolution, error)
 
-// AutoResolveConflicts resolves mergeConflicts using the resolver
-// indicated by resolverName.
+// AutoResolveConflicts resolves mergeConflicts using the resolver indicated by resolverName.
 func AutoResolveConflicts(conflicts map[string]MergeConflict, resolverName string) (map[string]MergeSolution, error) {
 	resolver, err := parseResolver(resolverName)
 	if err != nil {

--- a/merger/MergeConflictSolver_test.go
+++ b/merger/MergeConflictSolver_test.go
@@ -208,7 +208,7 @@ func TestSolveConflictByChoosingNewest(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func Test_GetResolver(t *testing.T) {
+func Test_parseResolver(t *testing.T) {
 	resolver, err := parseResolver("")
 	assert.NoError(t, err)
 	assert.Nil(t, resolver)

--- a/merger/MergeConflictSolver_test.go
+++ b/merger/MergeConflictSolver_test.go
@@ -1,11 +1,72 @@
 package merger
 
 import (
+	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/AndreasSko/go-jwlm/model"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestAutoResolveConflicts(t *testing.T) {
+	conflicts := map[string]MergeConflict{
+		"bookmarkCollision": {
+			Left: &model.Bookmark{
+				Title: "LeftBookmark",
+			},
+			Right: &model.Bookmark{
+				Title: "RightBookmark",
+			},
+		},
+		"noteCollision": {
+			Left: &model.Note{
+				GUID: "LeftNote",
+			},
+			Right: &model.Note{
+				GUID: "RightNote",
+			},
+		},
+	}
+
+	// Choose left
+	expectedResult := map[string]MergeSolution{
+		"bookmarkCollision": {
+			Side: LeftSide,
+			Solution: &model.Bookmark{
+				Title: "LeftBookmark",
+			},
+			Discarded: &model.Bookmark{
+				Title: "RightBookmark",
+			},
+		},
+		"noteCollision": {
+			Side: LeftSide,
+			Solution: &model.Note{
+				GUID: "LeftNote",
+			},
+			Discarded: &model.Note{
+				GUID: "RightNote",
+			},
+		},
+	}
+
+	result, err := AutoResolveConflicts(conflicts, "chooseNewest")
+	assert.Error(t, err)
+	assert.Nil(t, result)
+
+	result, err = AutoResolveConflicts(conflicts, "wrongResolver")
+	assert.Error(t, err)
+	assert.Nil(t, result)
+
+	result, err = AutoResolveConflicts(conflicts, "")
+	assert.NoError(t, err)
+	assert.Nil(t, result)
+
+	result, err = AutoResolveConflicts(conflicts, "chooseLeft")
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResult, result)
+}
 
 func TestSolveConflictByChoosingX(t *testing.T) {
 	conflicts := map[string]MergeConflict{
@@ -145,4 +206,33 @@ func TestSolveConflictByChoosingNewest(t *testing.T) {
 	}
 	_, err = SolveConflictByChoosingNewest(conflicts)
 	assert.Error(t, err)
+}
+
+func Test_GetResolver(t *testing.T) {
+	resolver, err := parseResolver("")
+	assert.NoError(t, err)
+	assert.Nil(t, resolver)
+
+	// https://github.com/stretchr/testify/issues/182#issuecomment-495359313
+	resolver, err = parseResolver("chooseLeft")
+	assert.NoError(t, err)
+	assert.Equal(t,
+		"github.com/AndreasSko/go-jwlm/merger.SolveConflictByChoosingLeft",
+		runtime.FuncForPC(reflect.ValueOf(resolver).Pointer()).Name())
+
+	resolver, err = parseResolver("chooseRight")
+	assert.NoError(t, err)
+	assert.Equal(t,
+		"github.com/AndreasSko/go-jwlm/merger.SolveConflictByChoosingRight",
+		runtime.FuncForPC(reflect.ValueOf(resolver).Pointer()).Name())
+
+	resolver, err = parseResolver("chooseNewest")
+	assert.NoError(t, err)
+	assert.Equal(t,
+		"github.com/AndreasSko/go-jwlm/merger.SolveConflictByChoosingNewest",
+		runtime.FuncForPC(reflect.ValueOf(resolver).Pointer()).Name())
+
+	resolver, err = parseResolver("nonexistent")
+	assert.EqualError(t, err, "nonexistent is not a valid conflict resolver. Can be 'chooseNewest', 'chooseLeft', or 'chooseRight'")
+	assert.Nil(t, resolver)
 }


### PR DESCRIPTION
This introduces the package `go-jwlm/gomobile` that enables integrating go-jwlm into a mobile app. Because of current
limitations in Gomobile (see https://godoc.org/golang.org/x/mobile/cmd/gobind#hdr-Type_restrictions), the structs and most functionalities had to be wrapped.

The basic structure looks like this:
* The `DatabaseWrapper` wraps the left, right, and merged databases. It manages importing and exporting
* The merge functions (e.g. MergeLocations etc.) are called on the DatabaseWrapper
* Conflicts are handled using the `MergeConflictsWrapper`, which exports methods to view and solve possible conflicts
* To get some rough statistics, the `DatabaseStats` struct can be created

To create the actual binding, Gomobile needs to be installed (see https://github.com/golang/go/wiki/Mobile). Change into the go-jwlm/gomobile folder and run `gomobile bind -target ios` (in this case to target iOS), which will create the binding that can later be imported. The (WIP) implementation for iOS can be found here: https://github.com/AndreasSko/ios-jwlm