### PR TITLE
Custom MarshalJSON & get related entries

### DIFF
--- a/model/BlockRange.go
+++ b/model/BlockRange.go
@@ -56,6 +56,12 @@ func (m *BlockRange) Equals(m2 Model) bool {
 	return false
 }
 
+// RelatedEntries returns entries that are related to this one
+func (m *BlockRange) RelatedEntries(db *Database) []Model {
+	// We don't need it for now, so just return empty slice
+	return []Model{}
+}
+
 // PrettyPrint prints BlockRange in a human readable format and
 // adds information about related entries if helpful.
 func (m *BlockRange) PrettyPrint(db *Database) string {

--- a/model/BlockRange.go
+++ b/model/BlockRange.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"database/sql"
+	"encoding/json"
 	"strconv"
 	"strings"
 )
@@ -60,6 +61,27 @@ func (m *BlockRange) Equals(m2 Model) bool {
 func (m *BlockRange) PrettyPrint(db *Database) string {
 	fields := []string{"Identifier", "StartToken", "EndToken"}
 	return prettyPrint(m, fields)
+}
+
+// MarshalJSON returns the JSON encoding of the entry
+func (m BlockRange) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Type         string
+		BlockRangeID int
+		BlockType    int
+		Identifier   int
+		StartToken   sql.NullInt32
+		EndToken     sql.NullInt32
+		UserMarkID   int
+	}{
+		Type:         "BlockRange",
+		BlockRangeID: m.BlockRangeID,
+		BlockType:    m.BlockType,
+		Identifier:   m.Identifier,
+		StartToken:   m.StartToken,
+		EndToken:     m.EndToken,
+		UserMarkID:   m.UserMarkID,
+	})
 }
 
 func (m *BlockRange) tableName() string {

--- a/model/BlockRange_test.go
+++ b/model/BlockRange_test.go
@@ -105,6 +105,20 @@ func TestBlockRange_Equals(t *testing.T) {
 	assert.False(t, m1.Equals(m2))
 }
 
+func TestBlockRange_RelatedEntries(t *testing.T) {
+	m1 := &BlockRange{
+		BlockRangeID: 1,
+		BlockType:    1,
+		Identifier:   1,
+		StartToken:   sql.NullInt32{Int32: 1, Valid: true},
+		EndToken:     sql.NullInt32{Int32: 2, Valid: true},
+		UserMarkID:   1,
+	}
+
+	assert.Empty(t, m1.RelatedEntries(nil))
+	assert.Empty(t, m1.RelatedEntries(&Database{}))
+}
+
 func TestBlockRange_MarshalJSON(t *testing.T) {
 	m1 := &BlockRange{
 		BlockRangeID: 1,

--- a/model/BlockRange_test.go
+++ b/model/BlockRange_test.go
@@ -3,6 +3,7 @@ package model
 import (
 	"bytes"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"text/tabwriter"
@@ -102,4 +103,18 @@ func TestBlockRange_Equals(t *testing.T) {
 
 	assert.True(t, m1.Equals(m1_1))
 	assert.False(t, m1.Equals(m2))
+}
+
+func TestBlockRange_MarshalJSON(t *testing.T) {
+	m1 := &BlockRange{
+		BlockRangeID: 1,
+		BlockType:    1,
+		Identifier:   1,
+		StartToken:   sql.NullInt32{Int32: 1, Valid: true},
+		EndToken:     sql.NullInt32{Int32: 2, Valid: true},
+		UserMarkID:   1,
+	}
+	result, err := json.Marshal(m1)
+	assert.NoError(t, err)
+	assert.Equal(t, `{"Type":"BlockRange","BlockRangeID":1,"BlockType":1,"Identifier":1,"StartToken":{"Int32":1,"Valid":true},"EndToken":{"Int32":2,"Valid":true},"UserMarkID":1}`, string(result))
 }

--- a/model/Bookmark.go
+++ b/model/Bookmark.go
@@ -56,6 +56,17 @@ func (m *Bookmark) Equals(m2 Model) bool {
 	return false
 }
 
+// RelatedEntries returns entries that are related to this one
+func (m *Bookmark) RelatedEntries(db *Database) []Model {
+	result := make([]Model, 0, 1)
+
+	if location := db.FetchFromTable("Location", m.LocationID); location != nil {
+		result = append(result, location)
+	}
+
+	return result
+}
+
 // PrettyPrint prints Bookmark in a human readable format and
 // adds information about related entries if helpful.
 func (m *Bookmark) PrettyPrint(db *Database) string {

--- a/model/Bookmark.go
+++ b/model/Bookmark.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"database/sql"
+	"encoding/json"
 	"strconv"
 	"strings"
 )
@@ -67,6 +68,31 @@ func (m *Bookmark) PrettyPrint(db *Database) string {
 	}
 
 	return result
+}
+
+// MarshalJSON returns the JSON encoding of the entry
+func (m Bookmark) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Type                  string
+		BookmarkID            int
+		LocationID            int
+		PublicationLocationID int
+		Slot                  int
+		Title                 string
+		Snippet               sql.NullString
+		BlockType             int
+		BlockIdentifier       sql.NullInt32
+	}{
+		Type:                  "Bookmark",
+		BookmarkID:            m.BookmarkID,
+		LocationID:            m.LocationID,
+		PublicationLocationID: m.PublicationLocationID,
+		Slot:                  m.Slot,
+		Title:                 m.Title,
+		Snippet:               m.Snippet,
+		BlockType:             m.BlockType,
+		BlockIdentifier:       m.BlockIdentifier,
+	})
 }
 
 func (m *Bookmark) tableName() string {

--- a/model/Bookmark_test.go
+++ b/model/Bookmark_test.go
@@ -118,6 +118,35 @@ func TestBookmark_PrettyPrint(t *testing.T) {
 	assert.Equal(t, expectedResult, m1.PrettyPrint(db))
 }
 
+func TestBookmark_RelatedEntries(t *testing.T) {
+	db := &Database{
+		Bookmark: []*Bookmark{
+			nil,
+			{
+				BookmarkID:            1,
+				LocationID:            1,
+				PublicationLocationID: 3,
+				Slot:                  4,
+				Title:                 "Test",
+				Snippet:               sql.NullString{},
+				BlockType:             0,
+				BlockIdentifier:       sql.NullInt32{},
+			},
+		},
+		Location: []*Location{
+			nil,
+			{
+				LocationID: 1,
+				Title:      sql.NullString{"Location-Title", true},
+			},
+		},
+	}
+
+	assert.Empty(t, db.Bookmark[1].RelatedEntries(nil))
+	assert.Equal(t,
+		db.Location[1],
+		db.Bookmark[1].RelatedEntries(db)[0])
+}
 
 func TestBookmark_MarshalJSON(t *testing.T) {
 	m1 := &Bookmark{

--- a/model/Bookmark_test.go
+++ b/model/Bookmark_test.go
@@ -3,6 +3,7 @@ package model
 import (
 	"bytes"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"text/tabwriter"
@@ -115,4 +116,24 @@ func TestBookmark_PrettyPrint(t *testing.T) {
 	expectedResult = buf.String()
 
 	assert.Equal(t, expectedResult, m1.PrettyPrint(db))
+}
+
+
+func TestBookmark_MarshalJSON(t *testing.T) {
+	m1 := &Bookmark{
+		BookmarkID:            1,
+		LocationID:            2,
+		PublicationLocationID: 3,
+		Slot:                  4,
+		Title:                 "Test",
+		Snippet:               sql.NullString{"A snippet", true},
+		BlockType:             5,
+		BlockIdentifier:       sql.NullInt32{},
+	}
+
+	result, err := json.Marshal(m1)
+	assert.NoError(t, err)
+	assert.Equal(t,
+		`{"Type":"Bookmark","BookmarkID":1,"LocationID":2,"PublicationLocationID":3,"Slot":4,"Title":"Test","Snippet":{"String":"A snippet","Valid":true},"BlockType":5,"BlockIdentifier":{"Int32":0,"Valid":false}}`,
+		string(result))
 }

--- a/model/Location.go
+++ b/model/Location.go
@@ -69,6 +69,12 @@ func (m *Location) Equals(m2 Model) bool {
 	return false
 }
 
+// RelatedEntries returns entries that are related to this one
+func (m *Location) RelatedEntries(db *Database) []Model {
+	// We don't need it for now, so just return empty slice
+	return []Model{}
+}
+
 // PrettyPrint prints Location in a human readable format and
 // adds information about related entries if helpful.
 func (m *Location) PrettyPrint(db *Database) string {

--- a/model/Location.go
+++ b/model/Location.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"database/sql"
+	"encoding/json"
 	"strconv"
 	"strings"
 )
@@ -74,6 +75,35 @@ func (m *Location) PrettyPrint(db *Database) string {
 	fields := []string{"Title", "BookNumber", "ChapterNumber", "DocumentID", "Track",
 		"IssueTagNumber", "KeySymbol", "MepsLanguage"}
 	return prettyPrint(m, fields)
+}
+
+// MarshalJSON returns the JSON encoding of the entry
+func (m Location) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Type           string
+		LocationID     int
+		BookNumber     sql.NullInt32
+		ChapterNumber  sql.NullInt32
+		DocumentID     sql.NullInt32
+		Track          sql.NullInt32
+		IssueTagNumber int
+		KeySymbol      sql.NullString
+		MepsLanguage   int
+		LocationType   int
+		Title          sql.NullString
+	}{
+		Type:           "Location",
+		LocationID:     m.LocationID,
+		BookNumber:     m.BookNumber,
+		ChapterNumber:  m.ChapterNumber,
+		DocumentID:     m.DocumentID,
+		Track:          m.Track,
+		IssueTagNumber: m.IssueTagNumber,
+		KeySymbol:      m.KeySymbol,
+		MepsLanguage:   m.MepsLanguage,
+		LocationType:   m.LocationType,
+		Title:          m.Title,
+	})
 }
 
 func (m *Location) tableName() string {

--- a/model/Location_test.go
+++ b/model/Location_test.go
@@ -139,6 +139,24 @@ func TestLocation_Equals(t *testing.T) {
 	assert.False(t, m1.Equals(m2))
 }
 
+func TestLocation_RelatedEntries(t *testing.T) {
+	m1 := &Location{
+		LocationID:     1,
+		BookNumber:     sql.NullInt32{Int32: 2, Valid: true},
+		ChapterNumber:  sql.NullInt32{Int32: 3, Valid: true},
+		DocumentID:     sql.NullInt32{Int32: 4, Valid: true},
+		Track:          sql.NullInt32{Int32: 5, Valid: true},
+		IssueTagNumber: 6,
+		KeySymbol:      sql.NullString{String: "nwtsty", Valid: true},
+		MepsLanguage:   7,
+		LocationType:   8,
+		Title:          sql.NullString{String: "A title", Valid: true},
+	}
+
+	assert.Empty(t, m1.RelatedEntries(nil))
+	assert.Empty(t, m1.RelatedEntries(&Database{}))
+}
+
 func TestLocation_MarshalJSON(t *testing.T) {
 	m1 := &Location{
 		LocationID:     1,

--- a/model/Location_test.go
+++ b/model/Location_test.go
@@ -3,6 +3,7 @@ package model
 import (
 	"bytes"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"text/tabwriter"
@@ -136,4 +137,25 @@ func TestLocation_Equals(t *testing.T) {
 
 	assert.True(t, m1.Equals(m1_1))
 	assert.False(t, m1.Equals(m2))
+}
+
+func TestLocation_MarshalJSON(t *testing.T) {
+	m1 := &Location{
+		LocationID:     1,
+		BookNumber:     sql.NullInt32{Int32: 2, Valid: true},
+		ChapterNumber:  sql.NullInt32{Int32: 3, Valid: true},
+		DocumentID:     sql.NullInt32{Int32: 4, Valid: true},
+		Track:          sql.NullInt32{Int32: 5, Valid: true},
+		IssueTagNumber: 6,
+		KeySymbol:      sql.NullString{String: "nwtsty", Valid: true},
+		MepsLanguage:   7,
+		LocationType:   8,
+		Title:          sql.NullString{String: "ThisTitleShouldNotBeInUniqueKey", Valid: true},
+	}
+
+	result, err := json.Marshal(m1)
+	assert.NoError(t, err)
+	assert.Equal(t,
+		`{"Type":"Location","LocationID":1,"BookNumber":{"Int32":2,"Valid":true},"ChapterNumber":{"Int32":3,"Valid":true},"DocumentID":{"Int32":4,"Valid":true},"Track":{"Int32":5,"Valid":true},"IssueTagNumber":6,"KeySymbol":{"String":"nwtsty","Valid":true},"MepsLanguage":7,"LocationType":8,"Title":{"String":"ThisTitleShouldNotBeInUniqueKey","Valid":true}}`,
+		string(result))
 }

--- a/model/Model.go
+++ b/model/Model.go
@@ -20,6 +20,7 @@ type Model interface {
 	SetID(int)
 	UniqueKey() string
 	Equals(m2 Model) bool
+	RelatedEntries(db *Database) []Model
 	PrettyPrint(db *Database) string
 	tableName() string
 	idName() string

--- a/model/Note.go
+++ b/model/Note.go
@@ -44,12 +44,29 @@ func (m *Note) Equals(m2 Model) bool {
 	return false
 }
 
+// RelatedEntries returns entries that are related to this one
+func (m *Note) RelatedEntries(db *Database) []Model {
+	result := make([]Model, 0, 2)
+
+	if location := db.FetchFromTable("Location", int(m.LocationID.Int32)); location != nil {
+		result = append(result, location)
+	}
+
+	// Todo: Maybe add BlockRange or rather use UserMarkBlockRange?
+	if userMark := db.FetchFromTable("UserMark", int(m.UserMarkID.Int32)); userMark != nil {
+		result = append(result, userMark)
+	}
+
+	return result
+}
+
 // PrettyPrint prints Note in a human readable format and
 // adds information about related entries if helpful.
 func (m *Note) PrettyPrint(db *Database) string {
 	fields := []string{"Title", "Content", "LastModified"}
 	result := prettyPrint(m, fields)
 
+	// TODO: Use RelatedEntries
 	if location := db.FetchFromTable("Location", int(m.LocationID.Int32)); location != nil {
 		result += "\n\n\nRelated Location:\n"
 		result += location.PrettyPrint(db)

--- a/model/Note.go
+++ b/model/Note.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"database/sql"
+	"encoding/json"
 )
 
 // Note represents the Note table inside the JW Library database
@@ -60,6 +61,33 @@ func (m *Note) PrettyPrint(db *Database) string {
 	}
 
 	return result
+}
+
+// MarshalJSON returns the JSON encoding of the entry
+func (m Note) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Type            string
+		NoteID          int
+		GUID            string
+		UserMarkID      sql.NullInt32
+		LocationID      sql.NullInt32
+		Title           sql.NullString
+		Content         sql.NullString
+		LastModified    string
+		BlockType       int
+		BlockIdentifier sql.NullInt32
+	}{
+		Type:            "Note",
+		NoteID:          m.NoteID,
+		GUID:            m.GUID,
+		UserMarkID:      m.UserMarkID,
+		LocationID:      m.LocationID,
+		Title:           m.Title,
+		Content:         m.Content,
+		LastModified:    m.LastModified,
+		BlockType:       m.BlockType,
+		BlockIdentifier: m.BlockIdentifier,
+	})
 }
 
 func (m *Note) tableName() string {

--- a/model/Note_test.go
+++ b/model/Note_test.go
@@ -3,6 +3,7 @@ package model
 import (
 	"bytes"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"text/tabwriter"
@@ -125,4 +126,24 @@ func TestNote_PrettyPrint(t *testing.T) {
 	expectedResult = buf.String()
 
 	assert.Equal(t, expectedResult, m1.PrettyPrint(db))
+}
+
+func TestNote_MarshalJSON(t *testing.T) {
+	m1 := &Note{
+		NoteID:          1,
+		GUID:            "GUIDFOR1",
+		UserMarkID:      sql.NullInt32{Int32: 2, Valid: true},
+		LocationID:      sql.NullInt32{Int32: 3, Valid: true},
+		Title:           sql.NullString{String: "A Title", Valid: true},
+		Content:         sql.NullString{String: "The content", Valid: true},
+		LastModified:    "2017-06-01T19:36:28+0200",
+		BlockType:       4,
+		BlockIdentifier: sql.NullInt32{},
+	}
+
+	result, err := json.Marshal(m1)
+	assert.NoError(t, err)
+	assert.Equal(t,
+		`{"Type":"Note","NoteID":1,"GUID":"GUIDFOR1","UserMarkID":{"Int32":2,"Valid":true},"LocationID":{"Int32":3,"Valid":true},"Title":{"String":"A Title","Valid":true},"Content":{"String":"The content","Valid":true},"LastModified":"2017-06-01T19:36:28+0200","BlockType":4,"BlockIdentifier":{"Int32":0,"Valid":false}}`,
+		string(result))
 }

--- a/model/Note_test.go
+++ b/model/Note_test.go
@@ -76,6 +76,43 @@ func TestNote_Equals(t *testing.T) {
 	assert.True(t, m2.Equals(m2_1))
 }
 
+func TestNote_RelatedEntries(t *testing.T) {
+	db := &Database{
+		Location: []*Location{
+			nil,
+			{
+				LocationID: 1,
+				Title:      sql.NullString{"Location-Title", true},
+			},
+		},
+		Note: []*Note{
+			nil,
+			{
+				NoteID:          1,
+				GUID:            "GUIDFOR1",
+				UserMarkID:      sql.NullInt32{Int32: 1, Valid: true},
+				LocationID:      sql.NullInt32{Int32: 1, Valid: true},
+				Title:           sql.NullString{String: "A Title", Valid: true},
+				Content:         sql.NullString{String: "Content", Valid: true},
+				LastModified:    "2017-06-01T19:36:28+0200",
+				BlockType:       0,
+				BlockIdentifier: sql.NullInt32{},
+			},
+		},
+		UserMark: []*UserMark{
+			nil,
+			{
+				UserMarkID: 1,
+				ColorIndex: 5,
+			},
+		},
+	}
+
+	assert.Empty(t, db.Note[1].RelatedEntries(nil))
+	assert.Equal(t, db.Location[1], db.Note[1].RelatedEntries(db)[0])
+	assert.Equal(t, db.UserMark[1], db.Note[1].RelatedEntries(db)[1])
+}
+
 func TestNote_PrettyPrint(t *testing.T) {
 	m1 := &Note{
 		NoteID:          1,

--- a/model/Tag.go
+++ b/model/Tag.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"database/sql"
+	"encoding/json"
 	"strconv"
 	"strings"
 )
@@ -52,6 +53,23 @@ func (m *Tag) Equals(m2 Model) bool {
 func (m *Tag) PrettyPrint(db *Database) string {
 	fields := []string{"Name"}
 	return prettyPrint(m, fields)
+}
+
+// MarshalJSON returns the JSON encoding of the entry
+func (m Tag) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Type          string
+		TagID         int
+		TagType       int
+		Name          string
+		ImageFilename sql.NullString
+	}{
+		Type:          "Tag",
+		TagID:         m.TagID,
+		TagType:       m.TagType,
+		Name:          m.Name,
+		ImageFilename: m.ImageFilename,
+	})
 }
 
 func (m *Tag) tableName() string {

--- a/model/Tag.go
+++ b/model/Tag.go
@@ -48,6 +48,11 @@ func (m *Tag) Equals(m2 Model) bool {
 	return false
 }
 
+// RelatedEntries returns entries that are related to this one
+func (m *Tag) RelatedEntries(db *Database) []Model {
+	return []Model{}
+}
+
 // PrettyPrint prints Tag in a human readable format and
 // adds information about related entries if helpful.
 func (m *Tag) PrettyPrint(db *Database) string {

--- a/model/TagMap.go
+++ b/model/TagMap.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"database/sql"
+	"encoding/json"
 	"strconv"
 	"strings"
 )
@@ -58,6 +59,27 @@ func (m *TagMap) Equals(m2 Model) bool {
 // adds information about related entries if helpful.
 func (m *TagMap) PrettyPrint(db *Database) string {
 	panic("Not supported")
+}
+
+// MarshalJSON returns the JSON encoding of the entry
+func (m TagMap) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Type           string
+		TagMapID       int
+		PlaylistItemID sql.NullInt32
+		LocationID     sql.NullInt32
+		NoteID         sql.NullInt32
+		TagID          int
+		Position       int
+	}{
+		Type:           "TagMap",
+		TagMapID:       m.TagMapID,
+		PlaylistItemID: m.PlaylistItemID,
+		LocationID:     m.LocationID,
+		NoteID:         m.NoteID,
+		TagID:          m.TagID,
+		Position:       m.Position,
+	})
 }
 
 func (m *TagMap) tableName() string {

--- a/model/TagMap.go
+++ b/model/TagMap.go
@@ -55,6 +55,12 @@ func (m *TagMap) Equals(m2 Model) bool {
 	return false
 }
 
+// RelatedEntries returns entries that are related to this one
+func (m *TagMap) RelatedEntries(db *Database) []Model {
+	// We don't need it for now, so just return empty slice
+	return []Model{}
+}
+
 // PrettyPrint prints TagMap in a human readable format and
 // adds information about related entries if helpful.
 func (m *TagMap) PrettyPrint(db *Database) string {

--- a/model/TagMap_test.go
+++ b/model/TagMap_test.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"database/sql"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -73,4 +74,22 @@ func TestTagMap_Equals(t *testing.T) {
 
 	assert.True(t, m1.Equals(m1_1))
 	assert.False(t, m1.Equals(m2))
+}
+
+
+func TestTagMap_MarshalJSON(t *testing.T) {
+	m1 := &TagMap{
+		TagMapID:       1,
+		PlaylistItemID: sql.NullInt32{2, true},
+		LocationID:     sql.NullInt32{3, true},
+		NoteID:         sql.NullInt32{4, true},
+		TagID:          5,
+		Position:       6,
+	}
+
+	result, err := json.Marshal(m1)
+	assert.NoError(t, err)
+	assert.Equal(t,
+		`{"Type":"TagMap","TagMapID":1,"PlaylistItemID":{"Int32":2,"Valid":true},"LocationID":{"Int32":3,"Valid":true},"NoteID":{"Int32":4,"Valid":true},"TagID":5,"Position":6}`,
+		string(result))
 }

--- a/model/TagMap_test.go
+++ b/model/TagMap_test.go
@@ -76,6 +76,19 @@ func TestTagMap_Equals(t *testing.T) {
 	assert.False(t, m1.Equals(m2))
 }
 
+func TestTagMap_RelatedEntries(t *testing.T) {
+	m1 := &TagMap{
+		TagMapID:       1,
+		PlaylistItemID: sql.NullInt32{1, true},
+		LocationID:     sql.NullInt32{1, true},
+		NoteID:         sql.NullInt32{1, true},
+		TagID:          1,
+		Position:       1,
+	}
+
+	assert.Empty(t, m1.RelatedEntries(nil))
+	assert.Empty(t, m1.RelatedEntries(&Database{}))
+}
 
 func TestTagMap_MarshalJSON(t *testing.T) {
 	m1 := &TagMap{

--- a/model/Tag_test.go
+++ b/model/Tag_test.go
@@ -87,6 +87,18 @@ func TestTag_PrettyPrint(t *testing.T) {
 	assert.Equal(t, expectedResult, m1.PrettyPrint(nil))
 }
 
+func TestTag_RelatedEntries(t *testing.T) {
+	m1 := &Tag{
+		TagID:         1,
+		TagType:       1,
+		Name:          "FirstTag",
+		ImageFilename: sql.NullString{},
+	}
+
+	assert.Empty(t, m1.RelatedEntries(nil))
+	assert.Empty(t, m1.RelatedEntries(&Database{}))
+}
+
 func TestTag_MarshalJSON(t *testing.T) {
 	m1 := &Tag{
 		TagID:         1,

--- a/model/Tag_test.go
+++ b/model/Tag_test.go
@@ -3,6 +3,7 @@ package model
 import (
 	"bytes"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"text/tabwriter"
@@ -84,4 +85,19 @@ func TestTag_PrettyPrint(t *testing.T) {
 	expectedResult := buf.String()
 
 	assert.Equal(t, expectedResult, m1.PrettyPrint(nil))
+}
+
+func TestTag_MarshalJSON(t *testing.T) {
+	m1 := &Tag{
+		TagID:         1,
+		TagType:       2,
+		Name:          "FirstTag",
+		ImageFilename: sql.NullString{},
+	}
+
+	result, err := json.Marshal(m1)
+	assert.NoError(t, err)
+	assert.Equal(t,
+		`{"Type":"Tag","TagID":1,"TagType":2,"Name":"FirstTag","ImageFilename":{"String":"","Valid":false}}`,
+		string(result))
 }

--- a/model/UserMark.go
+++ b/model/UserMark.go
@@ -42,6 +42,12 @@ func (m *UserMark) Equals(m2 Model) bool {
 	return false
 }
 
+// RelatedEntries returns entries that are related to this one
+func (m *UserMark) RelatedEntries(db *Database) []Model {
+	// We don't need it for now, so just return empty slice
+	return []Model{}
+}
+
 // PrettyPrint prints UserMark in a human readable format and
 // adds information about related entries if helpful.
 func (m *UserMark) PrettyPrint(db *Database) string {

--- a/model/UserMark.go
+++ b/model/UserMark.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"database/sql"
+	"encoding/json"
 )
 
 // UserMark represents the UserMark table inside the JW Library database
@@ -48,6 +49,27 @@ func (m *UserMark) PrettyPrint(db *Database) string {
 	result := prettyPrint(m, fields)
 
 	return result
+}
+
+// MarshalJSON returns the JSON encoding of the entry
+func (m UserMark) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Type         string
+		UserMarkID   int
+		ColorIndex   int
+		LocationID   int
+		StyleIndex   int
+		UserMarkGUID string
+		Version      int
+	}{
+		Type:         "UserMark",
+		UserMarkID:   m.UserMarkID,
+		ColorIndex:   m.ColorIndex,
+		LocationID:   m.LocationID,
+		StyleIndex:   m.StyleIndex,
+		UserMarkGUID: m.UserMarkGUID,
+		Version:      m.Version,
+	})
 }
 
 func (m *UserMark) tableName() string {

--- a/model/UserMarkBlockRange.go
+++ b/model/UserMarkBlockRange.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"database/sql"
+	"encoding/json"
 	"reflect"
 	"regexp"
 	"strings"
@@ -83,6 +84,19 @@ func (m *UserMarkBlockRange) PrettyPrint(db *Database) string {
 	}
 
 	return result
+}
+
+// MarshalJSON returns the JSON encoding of the entry
+func (m UserMarkBlockRange) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Type        string
+		UserMark    *UserMark
+		BlockRanges []*BlockRange
+	}{
+		Type:        "UserMarkBlockRange",
+		UserMark:    m.UserMark,
+		BlockRanges: m.BlockRanges,
+	})
 }
 
 func (m *UserMarkBlockRange) tableName() string {

--- a/model/UserMarkBlockRange.go
+++ b/model/UserMarkBlockRange.go
@@ -65,6 +65,17 @@ func (m *UserMarkBlockRange) Equals(m2 Model) bool {
 		reflect.DeepEqual(mBRKeys, m2BRKeys)
 }
 
+// RelatedEntries returns entries that are related to this one
+func (m *UserMarkBlockRange) RelatedEntries(db *Database) []Model {
+	result := make([]Model, 0, 1)
+
+	if location := db.FetchFromTable("Location", m.UserMark.LocationID); location != nil {
+		result = append(result, location)
+	}
+
+	return result
+}
+
 // PrettyPrint prints UserMarkBlockRange in a human readable format and
 // adds information about related entries if helpful.
 func (m *UserMarkBlockRange) PrettyPrint(db *Database) string {

--- a/model/UserMarkBlockRange_test.go
+++ b/model/UserMarkBlockRange_test.go
@@ -3,6 +3,7 @@ package model
 import (
 	"bytes"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"text/tabwriter"
@@ -291,4 +292,37 @@ func TestUserMarkBlockRange_PrettyPrint(t *testing.T) {
 	w.Flush()
 	expectedResult = buf.String()
 	assert.Equal(t, expectedResult, m1.PrettyPrint(db))
+}
+
+func TestUserMarkBlockRange_MarshalJSON(t *testing.T) {
+	m1 := &UserMarkBlockRange{
+		UserMark: &UserMark{
+			UserMarkID:   12345,
+			UserMarkGUID: "VERYUNIQUEID",
+		},
+		BlockRanges: []*BlockRange{
+			{
+				BlockRangeID: 1,
+				BlockType:    1,
+				Identifier:   1,
+				StartToken:   sql.NullInt32{Int32: 1, Valid: true},
+				EndToken:     sql.NullInt32{Int32: 2, Valid: true},
+				UserMarkID:   1,
+			},
+			{
+				BlockRangeID: 2,
+				BlockType:    1,
+				Identifier:   20,
+				StartToken:   sql.NullInt32{Int32: 15, Valid: true},
+				EndToken:     sql.NullInt32{Int32: 25, Valid: true},
+				UserMarkID:   1,
+			},
+		},
+	}
+
+	result, err := json.Marshal(m1)
+	assert.NoError(t, err)
+	assert.Equal(t,
+		`{"Type":"UserMarkBlockRange","UserMark":{"Type":"UserMark","UserMarkID":12345,"ColorIndex":0,"LocationID":0,"StyleIndex":0,"UserMarkGUID":"VERYUNIQUEID","Version":0},"BlockRanges":[{"Type":"BlockRange","BlockRangeID":1,"BlockType":1,"Identifier":1,"StartToken":{"Int32":1,"Valid":true},"EndToken":{"Int32":2,"Valid":true},"UserMarkID":1},{"Type":"BlockRange","BlockRangeID":2,"BlockType":1,"Identifier":20,"StartToken":{"Int32":15,"Valid":true},"EndToken":{"Int32":25,"Valid":true},"UserMarkID":1}]}`,
+		string(result))
 }

--- a/model/UserMarkBlockRange_test.go
+++ b/model/UserMarkBlockRange_test.go
@@ -294,6 +294,57 @@ func TestUserMarkBlockRange_PrettyPrint(t *testing.T) {
 	assert.Equal(t, expectedResult, m1.PrettyPrint(db))
 }
 
+func TestUserMarkBlockRange_RelatedEntries(t *testing.T) {
+	db := &Database{
+		Location: []*Location{
+			nil,
+			{
+				LocationID: 1,
+				Title:      sql.NullString{"Location-Title", true},
+			},
+		},
+	}
+	m1 := &UserMarkBlockRange{
+		UserMark: &UserMark{
+			UserMarkID:   1,
+			ColorIndex:   5,
+			LocationID:   1,
+			StyleIndex:   1,
+			UserMarkGUID: "FIRST",
+			Version:      1,
+		},
+		BlockRanges: []*BlockRange{
+			{
+				BlockRangeID: 1,
+				BlockType:    1,
+				Identifier:   1,
+				StartToken:   sql.NullInt32{0, true},
+				EndToken:     sql.NullInt32{5, true},
+				UserMarkID:   1,
+			},
+			{
+				BlockRangeID: 2,
+				BlockType:    1,
+				Identifier:   2,
+				StartToken:   sql.NullInt32{0, true},
+				EndToken:     sql.NullInt32{4, true},
+				UserMarkID:   1,
+			},
+			{
+				BlockRangeID: 3,
+				BlockType:    1,
+				Identifier:   3,
+				StartToken:   sql.NullInt32{0, true},
+				EndToken:     sql.NullInt32{20, true},
+				UserMarkID:   1,
+			},
+		},
+	}
+
+	assert.Empty(t, m1.RelatedEntries(nil))
+	assert.Equal(t, db.Location[1], m1.RelatedEntries(db)[0])
+}
+
 func TestUserMarkBlockRange_MarshalJSON(t *testing.T) {
 	m1 := &UserMarkBlockRange{
 		UserMark: &UserMark{

--- a/model/UserMark_test.go
+++ b/model/UserMark_test.go
@@ -60,6 +60,20 @@ func TestUserMark_PrettyPrint(t *testing.T) {
 	assert.Equal(t, "\nColorIndex: 1", m1.PrettyPrint(nil))
 }
 
+func TestUserMark_RelatedEntries(t *testing.T) {
+	m1 := &UserMark{
+		UserMarkID:   1,
+		ColorIndex:   1,
+		LocationID:   1,
+		StyleIndex:   1,
+		UserMarkGUID: "FIRST",
+		Version:      1,
+	}
+
+	assert.Empty(t, m1.RelatedEntries(nil))
+	assert.Empty(t, m1.RelatedEntries(&Database{}))
+}
+
 func TestUserMark_MarshalJSON(t *testing.T) {
 	m1 := &UserMark{
 		UserMarkID:   1,

--- a/model/UserMark_test.go
+++ b/model/UserMark_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -57,4 +58,21 @@ func TestUserMark_PrettyPrint(t *testing.T) {
 	}
 
 	assert.Equal(t, "\nColorIndex: 1", m1.PrettyPrint(nil))
+}
+
+func TestUserMark_MarshalJSON(t *testing.T) {
+	m1 := &UserMark{
+		UserMarkID:   1,
+		ColorIndex:   2,
+		LocationID:   3,
+		StyleIndex:   4,
+		UserMarkGUID: "FIRST",
+		Version:      5,
+	}
+
+	result, err := json.Marshal(m1)
+	assert.NoError(t, err)
+	assert.Equal(t,
+		`{"Type":"UserMark","UserMarkID":1,"ColorIndex":2,"LocationID":3,"StyleIndex":4,"UserMarkGUID":"FIRST","Version":5}`,
+		string(result))
 }


### PR DESCRIPTION
* Adding a custom `MarshalJSON` method for the models, so the type can be included in the JSON encoding. This makes it possible to distinguish different models when only looking a the JSON object.
* The method `RelatedEntries` returns the entries that are related to a entry. It is similar to the implementation for prettyPrint, but is going to be used for the mobile binding.
