### PR TITLE
Mobile: Conflicts as JSON & use struct for relatedEntries

### DIFF
--- a/gomobile/MergeConflict.go
+++ b/gomobile/MergeConflict.go
@@ -40,8 +40,8 @@ type MergeConflict struct {
 
 // modelRelatedTuple contains a model and its related entries
 type modelRelatedTuple struct {
-	Model   model.Model
-	Related model.Related
+	Model   model.Model   `json:"model"`
+	Related model.Related `json:"related"`
 }
 
 // InitDBWrapper initializes the DatabaseWrapper for the MergeConflictsWrapper

--- a/gomobile/MergeConflict.go
+++ b/gomobile/MergeConflict.go
@@ -41,7 +41,7 @@ type MergeConflict struct {
 // modelRelatedTuple contains a model and its related entries
 type modelRelatedTuple struct {
 	Model   model.Model
-	Related []model.Model
+	Related model.Related
 }
 
 // InitDBWrapper initializes the DatabaseWrapper for the MergeConflictsWrapper

--- a/gomobile/MergeConflict_test.go
+++ b/gomobile/MergeConflict_test.go
@@ -153,13 +153,13 @@ func TestMergeConflictsWrapper_GetConflict(t *testing.T) {
 	assert.Equal(t,
 		jsonMarhshalIgnoreErr(modelRelatedTuple{
 			Model:   mcw.conflicts["1"].Left,
-			Related: []model.Model{db.Location[1]},
+			Related: model.Related{Location: db.Location[1], PublicationLocation: db.Location[1]},
 		}),
 		conflict.Left)
 	assert.Equal(t,
 		jsonMarhshalIgnoreErr(modelRelatedTuple{
 			Model:   mcw.conflicts["1"].Right,
-			Related: []model.Model{db.Location[1]},
+			Related: model.Related{Location: db.Location[1], PublicationLocation: db.Location[1]},
 		}),
 		conflict.Right)
 
@@ -168,13 +168,13 @@ func TestMergeConflictsWrapper_GetConflict(t *testing.T) {
 	assert.Equal(t,
 		jsonMarhshalIgnoreErr(modelRelatedTuple{
 			Model:   mcw.conflicts["2"].Left,
-			Related: []model.Model{},
+			Related: model.Related{},
 		}),
 		conflict.Left)
 	assert.Equal(t,
 		jsonMarhshalIgnoreErr(modelRelatedTuple{
 			Model:   mcw.conflicts["2"].Right,
-			Related: []model.Model{},
+			Related: model.Related{},
 		}),
 		conflict.Right)
 
@@ -182,7 +182,7 @@ func TestMergeConflictsWrapper_GetConflict(t *testing.T) {
 	assert.Equal(t,
 		jsonMarhshalIgnoreErr(modelRelatedTuple{
 			Model:   mcw.conflicts["2"].Right,
-			Related: []model.Model{},
+			Related: model.Related{},
 		}),
 		conflict.Right)
 

--- a/model/BlockRange.go
+++ b/model/BlockRange.go
@@ -72,13 +72,13 @@ func (m *BlockRange) PrettyPrint(db *Database) string {
 // MarshalJSON returns the JSON encoding of the entry
 func (m BlockRange) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
-		Type         string
-		BlockRangeID int
-		BlockType    int
-		Identifier   int
-		StartToken   sql.NullInt32
-		EndToken     sql.NullInt32
-		UserMarkID   int
+		Type         string        `json:"type"`
+		BlockRangeID int           `json:"blockRangeId"`
+		BlockType    int           `json:"blockType"`
+		Identifier   int           `json:"identifier"`
+		StartToken   sql.NullInt32 `json:"startToken"`
+		EndToken     sql.NullInt32 `json:"endToken"`
+		UserMarkID   int           `json:"userMarkId"`
 	}{
 		Type:         "BlockRange",
 		BlockRangeID: m.BlockRangeID,

--- a/model/BlockRange.go
+++ b/model/BlockRange.go
@@ -57,9 +57,9 @@ func (m *BlockRange) Equals(m2 Model) bool {
 }
 
 // RelatedEntries returns entries that are related to this one
-func (m *BlockRange) RelatedEntries(db *Database) []Model {
-	// We don't need it for now, so just return empty slice
-	return []Model{}
+func (m *BlockRange) RelatedEntries(db *Database) Related {
+	// We don't need it for now
+	return Related{}
 }
 
 // PrettyPrint prints BlockRange in a human readable format and

--- a/model/BlockRange_test.go
+++ b/model/BlockRange_test.go
@@ -130,5 +130,5 @@ func TestBlockRange_MarshalJSON(t *testing.T) {
 	}
 	result, err := json.Marshal(m1)
 	assert.NoError(t, err)
-	assert.Equal(t, `{"Type":"BlockRange","BlockRangeID":1,"BlockType":1,"Identifier":1,"StartToken":{"Int32":1,"Valid":true},"EndToken":{"Int32":2,"Valid":true},"UserMarkID":1}`, string(result))
+	assert.Equal(t, `{"type":"BlockRange","blockRangeId":1,"blockType":1,"identifier":1,"startToken":{"Int32":1,"Valid":true},"endToken":{"Int32":2,"Valid":true},"userMarkId":1}`, string(result))
 }

--- a/model/BlockRange_test.go
+++ b/model/BlockRange_test.go
@@ -115,8 +115,8 @@ func TestBlockRange_RelatedEntries(t *testing.T) {
 		UserMarkID:   1,
 	}
 
-	assert.Empty(t, m1.RelatedEntries(nil))
-	assert.Empty(t, m1.RelatedEntries(&Database{}))
+	assert.Equal(t, Related{}, m1.RelatedEntries(nil))
+	assert.Equal(t, Related{}, m1.RelatedEntries(&Database{}))
 }
 
 func TestBlockRange_MarshalJSON(t *testing.T) {

--- a/model/Bookmark.go
+++ b/model/Bookmark.go
@@ -87,15 +87,15 @@ func (m *Bookmark) PrettyPrint(db *Database) string {
 // MarshalJSON returns the JSON encoding of the entry
 func (m Bookmark) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
-		Type                  string
-		BookmarkID            int
-		LocationID            int
-		PublicationLocationID int
-		Slot                  int
-		Title                 string
-		Snippet               sql.NullString
-		BlockType             int
-		BlockIdentifier       sql.NullInt32
+		Type                  string         `json:"type"`
+		BookmarkID            int            `json:"bookmarkId"`
+		LocationID            int            `json:"locationId"`
+		PublicationLocationID int            `json:"publicationLocationId"`
+		Slot                  int            `json:"slot"`
+		Title                 string         `json:"title"`
+		Snippet               sql.NullString `json:"snippet"`
+		BlockType             int            `json:"blockType"`
+		BlockIdentifier       sql.NullInt32  `json:"blockIdentifier"`
 	}{
 		Type:                  "Bookmark",
 		BookmarkID:            m.BookmarkID,

--- a/model/Bookmark.go
+++ b/model/Bookmark.go
@@ -57,11 +57,14 @@ func (m *Bookmark) Equals(m2 Model) bool {
 }
 
 // RelatedEntries returns entries that are related to this one
-func (m *Bookmark) RelatedEntries(db *Database) []Model {
-	result := make([]Model, 0, 1)
+func (m *Bookmark) RelatedEntries(db *Database) Related {
+	result := Related{}
 
 	if location := db.FetchFromTable("Location", m.LocationID); location != nil {
-		result = append(result, location)
+		result.Location = location.(*Location)
+	}
+	if pubLocation := db.FetchFromTable("Location", m.LocationID); pubLocation != nil {
+		result.PublicationLocation = pubLocation.(*Location)
 	}
 
 	return result

--- a/model/Bookmark_test.go
+++ b/model/Bookmark_test.go
@@ -163,6 +163,6 @@ func TestBookmark_MarshalJSON(t *testing.T) {
 	result, err := json.Marshal(m1)
 	assert.NoError(t, err)
 	assert.Equal(t,
-		`{"Type":"Bookmark","BookmarkID":1,"LocationID":2,"PublicationLocationID":3,"Slot":4,"Title":"Test","Snippet":{"String":"A snippet","Valid":true},"BlockType":5,"BlockIdentifier":{"Int32":0,"Valid":false}}`,
+		`{"type":"Bookmark","bookmarkId":1,"locationId":2,"publicationLocationId":3,"slot":4,"title":"Test","snippet":{"String":"A snippet","Valid":true},"blockType":5,"blockIdentifier":{"Int32":0,"Valid":false}}`,
 		string(result))
 }

--- a/model/Bookmark_test.go
+++ b/model/Bookmark_test.go
@@ -142,10 +142,10 @@ func TestBookmark_RelatedEntries(t *testing.T) {
 		},
 	}
 
-	assert.Empty(t, db.Bookmark[1].RelatedEntries(nil))
+	assert.Equal(t, Related{}, db.Bookmark[1].RelatedEntries(nil))
 	assert.Equal(t,
-		db.Location[1],
-		db.Bookmark[1].RelatedEntries(db)[0])
+		Related{Location: db.Location[1], PublicationLocation: db.Location[1]},
+		db.Bookmark[1].RelatedEntries(db))
 }
 
 func TestBookmark_MarshalJSON(t *testing.T) {

--- a/model/Location.go
+++ b/model/Location.go
@@ -70,9 +70,9 @@ func (m *Location) Equals(m2 Model) bool {
 }
 
 // RelatedEntries returns entries that are related to this one
-func (m *Location) RelatedEntries(db *Database) []Model {
-	// We don't need it for now, so just return empty slice
-	return []Model{}
+func (m *Location) RelatedEntries(db *Database) Related {
+	// We don't need it for now
+	return Related{}
 }
 
 // PrettyPrint prints Location in a human readable format and

--- a/model/Location.go
+++ b/model/Location.go
@@ -86,17 +86,17 @@ func (m *Location) PrettyPrint(db *Database) string {
 // MarshalJSON returns the JSON encoding of the entry
 func (m Location) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
-		Type           string
-		LocationID     int
-		BookNumber     sql.NullInt32
-		ChapterNumber  sql.NullInt32
-		DocumentID     sql.NullInt32
-		Track          sql.NullInt32
-		IssueTagNumber int
-		KeySymbol      sql.NullString
-		MepsLanguage   int
-		LocationType   int
-		Title          sql.NullString
+		Type           string         `json:"type"`
+		LocationID     int            `json:"locationId"`
+		BookNumber     sql.NullInt32  `json:"bookNumber"`
+		ChapterNumber  sql.NullInt32  `json:"chapterNumber"`
+		DocumentID     sql.NullInt32  `json:"documentId"`
+		Track          sql.NullInt32  `json:"track"`
+		IssueTagNumber int            `json:"issueTagNumber"`
+		KeySymbol      sql.NullString `json:"keySymbol"`
+		MepsLanguage   int            `json:"mepsLanguage"`
+		LocationType   int            `json:"locationType"`
+		Title          sql.NullString `json:"title"`
 	}{
 		Type:           "Location",
 		LocationID:     m.LocationID,

--- a/model/Location_test.go
+++ b/model/Location_test.go
@@ -174,6 +174,6 @@ func TestLocation_MarshalJSON(t *testing.T) {
 	result, err := json.Marshal(m1)
 	assert.NoError(t, err)
 	assert.Equal(t,
-		`{"Type":"Location","LocationID":1,"BookNumber":{"Int32":2,"Valid":true},"ChapterNumber":{"Int32":3,"Valid":true},"DocumentID":{"Int32":4,"Valid":true},"Track":{"Int32":5,"Valid":true},"IssueTagNumber":6,"KeySymbol":{"String":"nwtsty","Valid":true},"MepsLanguage":7,"LocationType":8,"Title":{"String":"ThisTitleShouldNotBeInUniqueKey","Valid":true}}`,
+		`{"type":"Location","locationId":1,"bookNumber":{"Int32":2,"Valid":true},"chapterNumber":{"Int32":3,"Valid":true},"documentId":{"Int32":4,"Valid":true},"track":{"Int32":5,"Valid":true},"issueTagNumber":6,"keySymbol":{"String":"nwtsty","Valid":true},"mepsLanguage":7,"locationType":8,"title":{"String":"ThisTitleShouldNotBeInUniqueKey","Valid":true}}`,
 		string(result))
 }

--- a/model/Location_test.go
+++ b/model/Location_test.go
@@ -153,8 +153,8 @@ func TestLocation_RelatedEntries(t *testing.T) {
 		Title:          sql.NullString{String: "A title", Valid: true},
 	}
 
-	assert.Empty(t, m1.RelatedEntries(nil))
-	assert.Empty(t, m1.RelatedEntries(&Database{}))
+	assert.Equal(t, Related{}, m1.RelatedEntries(nil))
+	assert.Equal(t, Related{}, m1.RelatedEntries(&Database{}))
 }
 
 func TestLocation_MarshalJSON(t *testing.T) {

--- a/model/Model.go
+++ b/model/Model.go
@@ -29,15 +29,15 @@ type Model interface {
 
 // Related combines entries that are related to a given model
 type Related struct {
-	BlockRange          []*BlockRange
-	Bookmark            *Bookmark
-	Location            *Location
-	PublicationLocation *Location
-	Note                *Note
-	Tag                 *Tag
-	TagMap              *TagMap
-	UserMark            *UserMark
-	UserMarkBlockRange  *UserMarkBlockRange
+	BlockRange          []*BlockRange       `json:"blockRange"`
+	Bookmark            *Bookmark           `json:"bookmark"`
+	Location            *Location           `json:"location"`
+	PublicationLocation *Location           `json:"publicationLocation"`
+	Note                *Note               `json:"note"`
+	Tag                 *Tag                `json:"tag"`
+	TagMap              *TagMap             `json:"tagMap"`
+	UserMark            *UserMark           `json:"userMark"`
+	UserMarkBlockRange  *UserMarkBlockRange `json:"userMarkBlockRange"`
 }
 
 // MakeModelSlice converts a slice of pointers of model-implementing structs to []model

--- a/model/Model.go
+++ b/model/Model.go
@@ -20,11 +20,24 @@ type Model interface {
 	SetID(int)
 	UniqueKey() string
 	Equals(m2 Model) bool
-	RelatedEntries(db *Database) []Model
+	RelatedEntries(db *Database) Related
 	PrettyPrint(db *Database) string
 	tableName() string
 	idName() string
 	scanRow(row *sql.Rows) (Model, error)
+}
+
+// Related combines entries that are related to a given model
+type Related struct {
+	BlockRange          []*BlockRange
+	Bookmark            *Bookmark
+	Location            *Location
+	PublicationLocation *Location
+	Note                *Note
+	Tag                 *Tag
+	TagMap              *TagMap
+	UserMark            *UserMark
+	UserMarkBlockRange  *UserMarkBlockRange
 }
 
 // MakeModelSlice converts a slice of pointers of model-implementing structs to []model

--- a/model/Note.go
+++ b/model/Note.go
@@ -45,16 +45,16 @@ func (m *Note) Equals(m2 Model) bool {
 }
 
 // RelatedEntries returns entries that are related to this one
-func (m *Note) RelatedEntries(db *Database) []Model {
-	result := make([]Model, 0, 2)
+func (m *Note) RelatedEntries(db *Database) Related {
+	result := Related{}
 
 	if location := db.FetchFromTable("Location", int(m.LocationID.Int32)); location != nil {
-		result = append(result, location)
+		result.Location = location.(*Location)
 	}
 
 	// Todo: Maybe add BlockRange or rather use UserMarkBlockRange?
 	if userMark := db.FetchFromTable("UserMark", int(m.UserMarkID.Int32)); userMark != nil {
-		result = append(result, userMark)
+		result.UserMark = userMark.(*UserMark)
 	}
 
 	return result

--- a/model/Note.go
+++ b/model/Note.go
@@ -83,16 +83,16 @@ func (m *Note) PrettyPrint(db *Database) string {
 // MarshalJSON returns the JSON encoding of the entry
 func (m Note) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
-		Type            string
-		NoteID          int
-		GUID            string
-		UserMarkID      sql.NullInt32
-		LocationID      sql.NullInt32
-		Title           sql.NullString
-		Content         sql.NullString
-		LastModified    string
-		BlockType       int
-		BlockIdentifier sql.NullInt32
+		Type            string         `json:"type"`
+		NoteID          int            `json:"noteId"`
+		GUID            string         `json:"guid"`
+		UserMarkID      sql.NullInt32  `json:"userMarkId"`
+		LocationID      sql.NullInt32  `json:"locationId"`
+		Title           sql.NullString `json:"title"`
+		Content         sql.NullString `json:"content"`
+		LastModified    string         `json:"lastModified"`
+		BlockType       int            `json:"blockType"`
+		BlockIdentifier sql.NullInt32  `json:"blockIdentifier"`
 	}{
 		Type:            "Note",
 		NoteID:          m.NoteID,

--- a/model/Note_test.go
+++ b/model/Note_test.go
@@ -108,9 +108,8 @@ func TestNote_RelatedEntries(t *testing.T) {
 		},
 	}
 
-	assert.Empty(t, db.Note[1].RelatedEntries(nil))
-	assert.Equal(t, db.Location[1], db.Note[1].RelatedEntries(db)[0])
-	assert.Equal(t, db.UserMark[1], db.Note[1].RelatedEntries(db)[1])
+	assert.Equal(t, Related{}, db.Note[1].RelatedEntries(nil))
+	assert.Equal(t, Related{Location: db.Location[1], UserMark: db.UserMark[1]}, db.Note[1].RelatedEntries(db))
 }
 
 func TestNote_PrettyPrint(t *testing.T) {

--- a/model/Note_test.go
+++ b/model/Note_test.go
@@ -180,6 +180,6 @@ func TestNote_MarshalJSON(t *testing.T) {
 	result, err := json.Marshal(m1)
 	assert.NoError(t, err)
 	assert.Equal(t,
-		`{"Type":"Note","NoteID":1,"GUID":"GUIDFOR1","UserMarkID":{"Int32":2,"Valid":true},"LocationID":{"Int32":3,"Valid":true},"Title":{"String":"A Title","Valid":true},"Content":{"String":"The content","Valid":true},"LastModified":"2017-06-01T19:36:28+0200","BlockType":4,"BlockIdentifier":{"Int32":0,"Valid":false}}`,
+		`{"type":"Note","noteId":1,"guid":"GUIDFOR1","userMarkId":{"Int32":2,"Valid":true},"locationId":{"Int32":3,"Valid":true},"title":{"String":"A Title","Valid":true},"content":{"String":"The content","Valid":true},"lastModified":"2017-06-01T19:36:28+0200","blockType":4,"blockIdentifier":{"Int32":0,"Valid":false}}`,
 		string(result))
 }

--- a/model/Tag.go
+++ b/model/Tag.go
@@ -49,8 +49,8 @@ func (m *Tag) Equals(m2 Model) bool {
 }
 
 // RelatedEntries returns entries that are related to this one
-func (m *Tag) RelatedEntries(db *Database) []Model {
-	return []Model{}
+func (m *Tag) RelatedEntries(db *Database) Related {
+	return Related{}
 }
 
 // PrettyPrint prints Tag in a human readable format and

--- a/model/Tag.go
+++ b/model/Tag.go
@@ -63,11 +63,11 @@ func (m *Tag) PrettyPrint(db *Database) string {
 // MarshalJSON returns the JSON encoding of the entry
 func (m Tag) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
-		Type          string
-		TagID         int
-		TagType       int
-		Name          string
-		ImageFilename sql.NullString
+		Type          string         `json:"type"`
+		TagID         int            `json:"tagId"`
+		TagType       int            `json:"tagType"`
+		Name          string         `json:"name"`
+		ImageFilename sql.NullString `json:"imageFilename"`
 	}{
 		Type:          "Tag",
 		TagID:         m.TagID,

--- a/model/TagMap.go
+++ b/model/TagMap.go
@@ -56,9 +56,9 @@ func (m *TagMap) Equals(m2 Model) bool {
 }
 
 // RelatedEntries returns entries that are related to this one
-func (m *TagMap) RelatedEntries(db *Database) []Model {
+func (m *TagMap) RelatedEntries(db *Database) Related {
 	// We don't need it for now, so just return empty slice
-	return []Model{}
+	return Related{}
 }
 
 // PrettyPrint prints TagMap in a human readable format and

--- a/model/TagMap.go
+++ b/model/TagMap.go
@@ -70,13 +70,13 @@ func (m *TagMap) PrettyPrint(db *Database) string {
 // MarshalJSON returns the JSON encoding of the entry
 func (m TagMap) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
-		Type           string
-		TagMapID       int
-		PlaylistItemID sql.NullInt32
-		LocationID     sql.NullInt32
-		NoteID         sql.NullInt32
-		TagID          int
-		Position       int
+		Type           string        `json:"type"`
+		TagMapID       int           `json:"tagMapId"`
+		PlaylistItemID sql.NullInt32 `json:"playlistItemId"`
+		LocationID     sql.NullInt32 `json:"locationId"`
+		NoteID         sql.NullInt32 `json:"noteId"`
+		TagID          int           `json:"tagId"`
+		Position       int           `json:"position"`
 	}{
 		Type:           "TagMap",
 		TagMapID:       m.TagMapID,

--- a/model/TagMap_test.go
+++ b/model/TagMap_test.go
@@ -103,6 +103,6 @@ func TestTagMap_MarshalJSON(t *testing.T) {
 	result, err := json.Marshal(m1)
 	assert.NoError(t, err)
 	assert.Equal(t,
-		`{"Type":"TagMap","TagMapID":1,"PlaylistItemID":{"Int32":2,"Valid":true},"LocationID":{"Int32":3,"Valid":true},"NoteID":{"Int32":4,"Valid":true},"TagID":5,"Position":6}`,
+		`{"type":"TagMap","tagMapId":1,"playlistItemId":{"Int32":2,"Valid":true},"locationId":{"Int32":3,"Valid":true},"noteId":{"Int32":4,"Valid":true},"tagId":5,"position":6}`,
 		string(result))
 }

--- a/model/TagMap_test.go
+++ b/model/TagMap_test.go
@@ -86,8 +86,8 @@ func TestTagMap_RelatedEntries(t *testing.T) {
 		Position:       1,
 	}
 
-	assert.Empty(t, m1.RelatedEntries(nil))
-	assert.Empty(t, m1.RelatedEntries(&Database{}))
+	assert.Equal(t, Related{}, m1.RelatedEntries(nil))
+	assert.Equal(t, Related{}, m1.RelatedEntries(&Database{}))
 }
 
 func TestTagMap_MarshalJSON(t *testing.T) {

--- a/model/Tag_test.go
+++ b/model/Tag_test.go
@@ -110,6 +110,6 @@ func TestTag_MarshalJSON(t *testing.T) {
 	result, err := json.Marshal(m1)
 	assert.NoError(t, err)
 	assert.Equal(t,
-		`{"Type":"Tag","TagID":1,"TagType":2,"Name":"FirstTag","ImageFilename":{"String":"","Valid":false}}`,
+		`{"type":"Tag","tagId":1,"tagType":2,"name":"FirstTag","imageFilename":{"String":"","Valid":false}}`,
 		string(result))
 }

--- a/model/Tag_test.go
+++ b/model/Tag_test.go
@@ -95,8 +95,8 @@ func TestTag_RelatedEntries(t *testing.T) {
 		ImageFilename: sql.NullString{},
 	}
 
-	assert.Empty(t, m1.RelatedEntries(nil))
-	assert.Empty(t, m1.RelatedEntries(&Database{}))
+	assert.Equal(t, Related{}, m1.RelatedEntries(nil))
+	assert.Equal(t, Related{}, m1.RelatedEntries(&Database{}))
 }
 
 func TestTag_MarshalJSON(t *testing.T) {

--- a/model/UserMark.go
+++ b/model/UserMark.go
@@ -60,13 +60,13 @@ func (m *UserMark) PrettyPrint(db *Database) string {
 // MarshalJSON returns the JSON encoding of the entry
 func (m UserMark) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
-		Type         string
-		UserMarkID   int
-		ColorIndex   int
-		LocationID   int
-		StyleIndex   int
-		UserMarkGUID string
-		Version      int
+		Type         string `json:"type"`
+		UserMarkID   int    `json:"userMarkId"`
+		ColorIndex   int    `json:"colorIndex"`
+		LocationID   int    `json:"locationId"`
+		StyleIndex   int    `json:"styleIndex"`
+		UserMarkGUID string `json:"userMarkGuid"`
+		Version      int    `json:"version"`
 	}{
 		Type:         "UserMark",
 		UserMarkID:   m.UserMarkID,

--- a/model/UserMark.go
+++ b/model/UserMark.go
@@ -43,9 +43,9 @@ func (m *UserMark) Equals(m2 Model) bool {
 }
 
 // RelatedEntries returns entries that are related to this one
-func (m *UserMark) RelatedEntries(db *Database) []Model {
+func (m *UserMark) RelatedEntries(db *Database) Related {
 	// We don't need it for now, so just return empty slice
-	return []Model{}
+	return Related{}
 }
 
 // PrettyPrint prints UserMark in a human readable format and

--- a/model/UserMarkBlockRange.go
+++ b/model/UserMarkBlockRange.go
@@ -100,9 +100,9 @@ func (m *UserMarkBlockRange) PrettyPrint(db *Database) string {
 // MarshalJSON returns the JSON encoding of the entry
 func (m UserMarkBlockRange) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
-		Type        string
-		UserMark    *UserMark
-		BlockRanges []*BlockRange
+		Type        string        `json:"type"`
+		UserMark    *UserMark     `json:"userMark"`
+		BlockRanges []*BlockRange `json:"blockRanges"`
 	}{
 		Type:        "UserMarkBlockRange",
 		UserMark:    m.UserMark,

--- a/model/UserMarkBlockRange.go
+++ b/model/UserMarkBlockRange.go
@@ -66,11 +66,11 @@ func (m *UserMarkBlockRange) Equals(m2 Model) bool {
 }
 
 // RelatedEntries returns entries that are related to this one
-func (m *UserMarkBlockRange) RelatedEntries(db *Database) []Model {
-	result := make([]Model, 0, 1)
+func (m *UserMarkBlockRange) RelatedEntries(db *Database) Related {
+	result := Related{}
 
 	if location := db.FetchFromTable("Location", m.UserMark.LocationID); location != nil {
-		result = append(result, location)
+		result.Location = location.(*Location)
 	}
 
 	return result

--- a/model/UserMarkBlockRange_test.go
+++ b/model/UserMarkBlockRange_test.go
@@ -341,8 +341,8 @@ func TestUserMarkBlockRange_RelatedEntries(t *testing.T) {
 		},
 	}
 
-	assert.Empty(t, m1.RelatedEntries(nil))
-	assert.Equal(t, db.Location[1], m1.RelatedEntries(db)[0])
+	assert.Equal(t, Related{}, m1.RelatedEntries(nil))
+	assert.Equal(t, Related{Location: db.Location[1]}, m1.RelatedEntries(db))
 }
 
 func TestUserMarkBlockRange_MarshalJSON(t *testing.T) {

--- a/model/UserMarkBlockRange_test.go
+++ b/model/UserMarkBlockRange_test.go
@@ -374,6 +374,6 @@ func TestUserMarkBlockRange_MarshalJSON(t *testing.T) {
 	result, err := json.Marshal(m1)
 	assert.NoError(t, err)
 	assert.Equal(t,
-		`{"Type":"UserMarkBlockRange","UserMark":{"Type":"UserMark","UserMarkID":12345,"ColorIndex":0,"LocationID":0,"StyleIndex":0,"UserMarkGUID":"VERYUNIQUEID","Version":0},"BlockRanges":[{"Type":"BlockRange","BlockRangeID":1,"BlockType":1,"Identifier":1,"StartToken":{"Int32":1,"Valid":true},"EndToken":{"Int32":2,"Valid":true},"UserMarkID":1},{"Type":"BlockRange","BlockRangeID":2,"BlockType":1,"Identifier":20,"StartToken":{"Int32":15,"Valid":true},"EndToken":{"Int32":25,"Valid":true},"UserMarkID":1}]}`,
+		`{"type":"UserMarkBlockRange","userMark":{"type":"UserMark","userMarkId":12345,"colorIndex":0,"locationId":0,"styleIndex":0,"userMarkGuid":"VERYUNIQUEID","version":0},"blockRanges":[{"type":"BlockRange","blockRangeId":1,"blockType":1,"identifier":1,"startToken":{"Int32":1,"Valid":true},"endToken":{"Int32":2,"Valid":true},"userMarkId":1},{"type":"BlockRange","blockRangeId":2,"blockType":1,"identifier":20,"startToken":{"Int32":15,"Valid":true},"endToken":{"Int32":25,"Valid":true},"userMarkId":1}]}`,
 		string(result))
 }

--- a/model/UserMark_test.go
+++ b/model/UserMark_test.go
@@ -87,6 +87,6 @@ func TestUserMark_MarshalJSON(t *testing.T) {
 	result, err := json.Marshal(m1)
 	assert.NoError(t, err)
 	assert.Equal(t,
-		`{"Type":"UserMark","UserMarkID":1,"ColorIndex":2,"LocationID":3,"StyleIndex":4,"UserMarkGUID":"FIRST","Version":5}`,
+		`{"type":"UserMark","userMarkId":1,"colorIndex":2,"locationId":3,"styleIndex":4,"userMarkGuid":"FIRST","version":5}`,
 		string(result))
 }

--- a/model/UserMark_test.go
+++ b/model/UserMark_test.go
@@ -70,8 +70,8 @@ func TestUserMark_RelatedEntries(t *testing.T) {
 		Version:      1,
 	}
 
-	assert.Empty(t, m1.RelatedEntries(nil))
-	assert.Empty(t, m1.RelatedEntries(&Database{}))
+	assert.Equal(t, Related{}, m1.RelatedEntries(nil))
+	assert.Equal(t, Related{}, m1.RelatedEntries(&Database{}))
 }
 
 func TestUserMark_MarshalJSON(t *testing.T) {


### PR DESCRIPTION
✨ Calling `GetConflict` returns the JSON representation of a Model, together with its related entries. This makes it possible to more dynamically present conflicts within the app. 
♻️ Added struct tags so JSON naming recommendations are followed when marshalling models.
♻️ Use struct for relatedEntries. This allows to easily detect if there actually exists, for example, a related Location, instead of needing to go through the whole slice.