### PR TITLE
🚑 Multiple bug fixes for merging markings

### DIFF
--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -74,7 +74,7 @@ func merge(leftFilename string, rightFilename string, mergedFilename string, std
 	fmt.Fprintln(stdio.Out, "Done.")
 
 	fmt.Fprintln(stdio.Out, "📑 Merging Bookmarks")
-	var bookmarksConflictSolution map[string]merger.MergeSolution
+	bookmarksConflictSolution := map[string]merger.MergeSolution{}
 	for {
 		mergedBookmarks, _, err := merger.MergeBookmarks(left.Bookmark, right.Bookmark, bookmarksConflictSolution)
 		if err == nil {
@@ -90,7 +90,8 @@ func merge(leftFilename string, rightFilename string, mergedFilename string, std
 					log.Fatal(resErr)
 				}
 			} else {
-				bookmarksConflictSolution = handleMergeConflict(err.Conflicts, &merged, stdio)
+				newSolutions := handleMergeConflict(err.Conflicts, &merged, stdio)
+				addToSolutions(bookmarksConflictSolution, newSolutions)
 			}
 		default:
 			log.Fatal(err)
@@ -117,7 +118,7 @@ func merge(leftFilename string, rightFilename string, mergedFilename string, std
 	fmt.Fprintln(stdio.Out, "Done.")
 
 	fmt.Fprintln(stdio.Out, "🖍  Merging Markings")
-	var UMBRConflictSolution map[string]merger.MergeSolution
+	UMBRConflictSolution := map[string]merger.MergeSolution{}
 	for {
 		mergedUserMarks, mergedBlockRanges, userMarkIDChanges, err := merger.MergeUserMarkAndBlockRange(left.UserMark, left.BlockRange, right.UserMark, right.BlockRange, UMBRConflictSolution)
 		if err == nil {
@@ -135,7 +136,8 @@ func merge(leftFilename string, rightFilename string, mergedFilename string, std
 					log.Fatal(resErr)
 				}
 			} else {
-				UMBRConflictSolution = handleMergeConflict(err.Conflicts, &merged, stdio)
+				newSolutions := handleMergeConflict(err.Conflicts, &merged, stdio)
+				addToSolutions(UMBRConflictSolution, newSolutions)
 			}
 		default:
 			log.Fatal(err)
@@ -144,7 +146,7 @@ func merge(leftFilename string, rightFilename string, mergedFilename string, std
 	fmt.Fprintln(stdio.Out, "Done.")
 
 	fmt.Fprintln(stdio.Out, "📝 Merging Notes")
-	var notesConflictSolution map[string]merger.MergeSolution
+	notesConflictSolution := map[string]merger.MergeSolution{}
 	for {
 		mergedNotes, notesIDChanges, err := merger.MergeNotes(left.Note, right.Note, notesConflictSolution)
 		if err == nil {
@@ -161,7 +163,8 @@ func merge(leftFilename string, rightFilename string, mergedFilename string, std
 					log.Fatal(resErr)
 				}
 			} else {
-				notesConflictSolution = handleMergeConflict(err.Conflicts, &merged, stdio)
+				newSolutions := handleMergeConflict(err.Conflicts, &merged, stdio)
+				addToSolutions(notesConflictSolution, newSolutions)
 			}
 		default:
 			log.Fatal(err)
@@ -193,6 +196,13 @@ func merge(leftFilename string, rightFilename string, mergedFilename string, std
 		log.Fatal(err)
 	}
 
+}
+
+// addToSolutions adds new mergeSolutions to the existing map of mergeSolutions
+func addToSolutions(solutions map[string]merger.MergeSolution, new map[string]merger.MergeSolution) {
+	for key, value := range new {
+		solutions[key] = value
+	}
 }
 
 func handleMergeConflict(conflicts map[string]merger.MergeConflict, mergedDB *model.Database, stdio terminal.Stdio) map[string]merger.MergeSolution {

--- a/gomobile/MergeConflict.go
+++ b/gomobile/MergeConflict.go
@@ -23,17 +23,17 @@ func (e MergeConflictError) Error() string {
 
 // MergeConflictsWrapper wraps mergeConflicts and their solutions
 type MergeConflictsWrapper struct {
-	DBWrapper       *DatabaseWrapper
-	conflicts       map[string]merger.MergeConflict
-	conflictKeys    []string
-	solvedConflicts int
-	solutions       map[string]merger.MergeSolution
+	DBWrapper         *DatabaseWrapper
+	conflicts         map[string]merger.MergeConflict
+	unsolvedConflicts map[string]bool
+	solutions         map[string]merger.MergeSolution
 }
 
 // MergeConflict represents two Models that collide. It is equvalent
 // to merger.MergeConflict, but represents the Models as strings
 // to make it compatible with Gomobile.
 type MergeConflict struct {
+	Key   string
 	Left  string
 	Right string
 }
@@ -59,67 +59,42 @@ func (mcw *MergeConflictsWrapper) addConflicts(conflicts map[string]merger.Merge
 		mcw.conflicts = make(map[string]merger.MergeConflict, len(conflicts))
 	}
 
-	if mcw.conflictKeys == nil {
-		mcw.conflictKeys = make([]string, 0, len(conflicts))
+	if mcw.unsolvedConflicts == nil {
+		mcw.unsolvedConflicts = make(map[string]bool, len(conflicts))
 	}
 
 	for key, value := range conflicts {
 		if _, exists := mcw.conflicts[key]; !exists {
 			mcw.conflicts[key] = value
-			mcw.conflictKeys = append(mcw.conflictKeys, key)
+			mcw.unsolvedConflicts[key] = true
 		}
 	}
 }
 
-// ConflictsLen returns the length of the conflicts map.
-func (mcw *MergeConflictsWrapper) ConflictsLen() int {
-	if mcw.conflicts == nil {
-		return 0
+// NextConflict returns the next conflict that should be solved. If there
+// are no left, it returns an error
+func (mcw *MergeConflictsWrapper) NextConflict() (*MergeConflict, error) {
+	if mcw.unsolvedConflicts == nil || len(mcw.unsolvedConflicts) == 0 {
+		return nil, errors.New("There are no unsolved conflicts")
 	}
-
-	return len(mcw.conflicts)
-}
-
-// SolutionsLen returns the length of the solutions slice
-func (mcw *MergeConflictsWrapper) SolutionsLen() int {
-	if mcw.solutions == nil {
-		return 0
-	}
-
-	return len(mcw.solutions)
-}
-
-// GetNextConflictIndex returns the next conflict index, for which
-// the conflict is not solved yet. If there are none left, it returns
-// -1 indicating that all conflicts have been solved.
-func (mcw *MergeConflictsWrapper) GetNextConflictIndex() int {
-	if mcw.solvedConflicts >= len(mcw.conflicts) {
-		return -1
-	}
-
-	return mcw.solvedConflicts
-}
-
-// GetConflict returns the conflict at index
-func (mcw *MergeConflictsWrapper) GetConflict(index int) (*MergeConflict, error) {
-	if mcw.conflicts == nil || mcw.conflictKeys == nil {
-		return nil, errors.New("There are no conflicts")
-	}
-
-	if index >= len(mcw.conflictKeys) {
-		return nil, fmt.Errorf("Conflict with index %d does not exist. Length=%d", index, len(mcw.conflictKeys))
-	}
-	key := mcw.conflictKeys[index]
 
 	if mcw.DBWrapper == nil {
 		mcw.DBWrapper = &DatabaseWrapper{merged: nil}
 	}
 
-	result := &MergeConflict{}
+	// Get any conflict
+	var conflictKey string
+	for key := range mcw.unsolvedConflicts {
+		conflictKey = key
+	}
+	conflict := mcw.conflicts[conflictKey]
 
+	result := &MergeConflict{
+		Key: conflictKey,
+	}
 	jsn, err := json.Marshal(modelRelatedTuple{
-		Model:   mcw.conflicts[key].Left,
-		Related: mcw.conflicts[key].Left.RelatedEntries(mcw.DBWrapper.merged),
+		Model:   conflict.Left,
+		Related: conflict.Left.RelatedEntries(mcw.DBWrapper.merged),
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "Error while marshalling to JSON")
@@ -127,8 +102,8 @@ func (mcw *MergeConflictsWrapper) GetConflict(index int) (*MergeConflict, error)
 	result.Left = string(jsn)
 
 	jsn, err = json.Marshal(modelRelatedTuple{
-		Model:   mcw.conflicts[key].Right,
-		Related: mcw.conflicts[key].Right.RelatedEntries(mcw.DBWrapper.merged),
+		Model:   conflict.Right,
+		Related: conflict.Right.RelatedEntries(mcw.DBWrapper.merged),
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "Error while marshalling to JSON")
@@ -138,26 +113,19 @@ func (mcw *MergeConflictsWrapper) GetConflict(index int) (*MergeConflict, error)
 	return result, nil
 }
 
-// SolveConflict solves a mergeConflict by choosing the given side at index.
-// Index must be less or equal to GetNextConflictIndex(), to ensure that
-// conflicts are solved in order and none are missed.
-func (mcw *MergeConflictsWrapper) SolveConflict(index int, side string) error {
-	if mcw.conflicts == nil || mcw.conflictKeys == nil {
-		return errors.New("There are no conflicts")
+// SolveConflict solves a mergeConflict represented by key and chooses the given side
+func (mcw *MergeConflictsWrapper) SolveConflict(key string, side string) error {
+	if mcw.unsolvedConflicts == nil || len(mcw.unsolvedConflicts) == 0 {
+		return errors.New("There are no unsolved conflicts")
 	}
-	if index >= len(mcw.conflictKeys) {
-		return fmt.Errorf("Conflict with index %d does not exist. Length=%d", index, len(mcw.conflictKeys))
-	}
-	if mcw.GetNextConflictIndex() != -1 && mcw.GetNextConflictIndex() < index {
-		return fmt.Errorf("Index is higher than NextConflictIndex: %d > %d. The conflicts before have to be solved first",
-			index, mcw.GetNextConflictIndex())
+	if _, exists := mcw.unsolvedConflicts[key]; !exists {
+		return errors.Errorf("Unsolved conflict with key %s does not exist", key)
 	}
 
 	if mcw.solutions == nil {
-		mcw.solutions = make(map[string]merger.MergeSolution, len(mcw.conflictKeys))
+		mcw.solutions = make(map[string]merger.MergeSolution, len(mcw.conflicts))
 	}
 
-	key := mcw.conflictKeys[index]
 	switch side {
 	case "leftSide":
 		mcw.solutions[key] = merger.MergeSolution{
@@ -175,9 +143,7 @@ func (mcw *MergeConflictsWrapper) SolveConflict(index int, side string) error {
 		return fmt.Errorf("Side %s is not valid", side)
 	}
 
-	if mcw.GetNextConflictIndex() == index {
-		mcw.solvedConflicts++
-	}
+	delete(mcw.unsolvedConflicts, key)
 
 	return nil
 }

--- a/gomobile/MergeConflict_test.go
+++ b/gomobile/MergeConflict_test.go
@@ -3,7 +3,6 @@ package gomobile
 import (
 	"database/sql"
 	"encoding/json"
-	"sort"
 	"testing"
 
 	"github.com/AndreasSko/go-jwlm/merger"
@@ -44,9 +43,8 @@ func TestMergeConflictsWrapper_addConflicts(t *testing.T) {
 
 	mcw := MergeConflictsWrapper{}
 	mcw.addConflicts(conflicts)
-	sort.Strings(mcw.conflictKeys)
 	assert.Equal(t, conflicts, mcw.conflicts)
-	assert.Equal(t, []string{"1", "2"}, mcw.conflictKeys)
+	assert.Equal(t, map[string]bool{"1": true, "2": true}, mcw.unsolvedConflicts)
 
 	conflicts["3"] = merger.MergeConflict{
 		Left: &model.Tag{
@@ -59,58 +57,10 @@ func TestMergeConflictsWrapper_addConflicts(t *testing.T) {
 
 	mcw.addConflicts(conflicts)
 	assert.Equal(t, conflicts, mcw.conflicts)
-	assert.Equal(t, []string{"1", "2", "3"}, mcw.conflictKeys)
+	assert.Equal(t, map[string]bool{"1": true, "2": true, "3": true}, mcw.unsolvedConflicts)
 }
 
-func TestMergeConflictsWrapper_ConflictsLen(t *testing.T) {
-	mcw := MergeConflictsWrapper{}
-	assert.Equal(t, 0, mcw.ConflictsLen())
-
-	mcw.conflicts = map[string]merger.MergeConflict{"1": {}, "2": {}, "3": {}}
-	assert.Equal(t, 3, mcw.ConflictsLen())
-}
-
-func TestMergeConflictsWrapper_SolutionsLen(t *testing.T) {
-	mcw := MergeConflictsWrapper{}
-	assert.Equal(t, 0, mcw.SolutionsLen())
-
-	mcw.solutions = map[string]merger.MergeSolution{"1": {}, "2": {}, "3": {}}
-	assert.Equal(t, 3, mcw.SolutionsLen())
-}
-
-func TestMergeConflictsWrapper_GetNextConflictIndex(t *testing.T) {
-	conflicts := map[string]merger.MergeConflict{
-		"1": {
-			Left: &model.Bookmark{
-				Title: "1Left",
-			},
-			Right: &model.Bookmark{
-				Title: "1Right",
-			},
-		},
-		"2": {
-			Left: &model.Tag{
-				Name: "2Left",
-			},
-			Right: &model.Tag{
-				Name: "2Right",
-			},
-		},
-	}
-
-	mcw := MergeConflictsWrapper{}
-	mcw.addConflicts(conflicts)
-
-	assert.Equal(t, 0, mcw.GetNextConflictIndex())
-	assert.Error(t, mcw.SolveConflict(1, "leftSide"))
-	assert.NoError(t, mcw.SolveConflict(0, "leftSide"))
-	assert.NoError(t, mcw.SolveConflict(0, "leftSide")) // Solving the same conflict should not increase counter
-	assert.Equal(t, 1, mcw.GetNextConflictIndex())
-	assert.NoError(t, mcw.SolveConflict(1, "leftSide"))
-	assert.Equal(t, -1, mcw.GetNextConflictIndex())
-}
-
-func TestMergeConflictsWrapper_GetConflict(t *testing.T) {
+func TestMergeConflictsWrapper_NextConflict(t *testing.T) {
 	db := &model.Database{
 		Location: []*model.Location{
 			nil,
@@ -145,53 +95,61 @@ func TestMergeConflictsWrapper_GetConflict(t *testing.T) {
 				},
 			},
 		},
-		conflictKeys: []string{"1", "2"},
+		unsolvedConflicts: map[string]bool{"1": true, "2": true},
 	}
 
-	conflict, err := mcw.GetConflict(0)
-	assert.NoError(t, err)
-	assert.Equal(t,
-		jsonMarhshalIgnoreErr(modelRelatedTuple{
-			Model:   mcw.conflicts["1"].Left,
-			Related: model.Related{Location: db.Location[1], PublicationLocation: db.Location[1]},
-		}),
-		conflict.Left)
-	assert.Equal(t,
-		jsonMarhshalIgnoreErr(modelRelatedTuple{
-			Model:   mcw.conflicts["1"].Right,
-			Related: model.Related{Location: db.Location[1], PublicationLocation: db.Location[1]},
-		}),
-		conflict.Right)
+	expectedConflicts := map[string]*MergeConflict{
+		"1": {
+			Key: "1",
+			Left: jsonMarhshalIgnoreErr(modelRelatedTuple{
+				Model:   mcw.conflicts["1"].Left,
+				Related: model.Related{Location: db.Location[1], PublicationLocation: db.Location[1]},
+			}),
+			Right: jsonMarhshalIgnoreErr(modelRelatedTuple{
+				Model:   mcw.conflicts["1"].Right,
+				Related: model.Related{Location: db.Location[1], PublicationLocation: db.Location[1]},
+			}),
+		},
+		"2": {
+			Key: "2",
+			Left: jsonMarhshalIgnoreErr(modelRelatedTuple{
+				Model:   mcw.conflicts["2"].Left,
+				Related: model.Related{},
+			}),
+			Right: jsonMarhshalIgnoreErr(modelRelatedTuple{
+				Model:   mcw.conflicts["2"].Right,
+				Related: model.Related{},
+			}),
+		},
+	}
 
-	conflict, err = mcw.GetConflict(1)
-	assert.NoError(t, err)
-	assert.Equal(t,
-		jsonMarhshalIgnoreErr(modelRelatedTuple{
-			Model:   mcw.conflicts["2"].Left,
-			Related: model.Related{},
-		}),
-		conflict.Left)
-	assert.Equal(t,
-		jsonMarhshalIgnoreErr(modelRelatedTuple{
-			Model:   mcw.conflicts["2"].Right,
-			Related: model.Related{},
-		}),
-		conflict.Right)
+	conflicts := map[string]*MergeConflict{}
+	for {
+		conflict, err := mcw.NextConflict()
+		if err != nil {
+			assert.EqualError(t, err, "There are no unsolved conflicts")
+			break
+		}
+		conflicts[conflict.Key] = conflict
+		delete(mcw.unsolvedConflicts, conflict.Key)
+	}
+
+	assert.Equal(t, expectedConflicts, conflicts)
 
 	mcw.DBWrapper = nil
+	mcw.unsolvedConflicts["2"] = true
+	conflict, err := mcw.NextConflict()
+	assert.NoError(t, err)
 	assert.Equal(t,
 		jsonMarhshalIgnoreErr(modelRelatedTuple{
 			Model:   mcw.conflicts["2"].Right,
 			Related: model.Related{},
 		}),
 		conflict.Right)
+	delete(mcw.unsolvedConflicts, conflict.Key)
 
-	_, err = mcw.GetConflict(3)
-	assert.Error(t, err)
-
-	mcw.conflicts = nil
-	_, err = mcw.GetConflict(1)
-	assert.Error(t, err)
+	_, err = mcw.NextConflict()
+	assert.EqualError(t, err, "There are no unsolved conflicts")
 }
 
 func jsonMarhshalIgnoreErr(m interface{}) string {
@@ -201,7 +159,7 @@ func jsonMarhshalIgnoreErr(m interface{}) string {
 
 func TestMergeConflictsWrapper_SolveConflict(t *testing.T) {
 	mcw := MergeConflictsWrapper{}
-	assert.EqualError(t, mcw.SolveConflict(0, "leftSide"), "There are no conflicts")
+	assert.EqualError(t, mcw.SolveConflict("bla", "leftSide"), "There are no unsolved conflicts")
 
 	mcw = MergeConflictsWrapper{
 		conflicts: map[string]merger.MergeConflict{
@@ -221,22 +179,13 @@ func TestMergeConflictsWrapper_SolveConflict(t *testing.T) {
 					Name: "2Right",
 				},
 			},
-			"3": {
-				Left: &model.Tag{
-					Name: "3Left",
-				},
-				Right: &model.Tag{
-					Name: "3Right",
-				},
-			},
 		},
-		conflictKeys: []string{"1", "2", "3"},
+		unsolvedConflicts: map[string]bool{"1": true, "2": true},
 	}
-	assert.EqualError(t, mcw.SolveConflict(3, "leftSide"), "Conflict with index 3 does not exist. Length=3")
-	assert.EqualError(t, mcw.SolveConflict(1, "leftSide"), "Index is higher than NextConflictIndex: 1 > 0. The conflicts before have to be solved first")
-	assert.EqualError(t, mcw.SolveConflict(0, "wrongSide"), "Side wrongSide is not valid")
+	assert.EqualError(t, mcw.SolveConflict("5", "leftSide"), "Unsolved conflict with key 5 does not exist")
+	assert.EqualError(t, mcw.SolveConflict("1", "wrongSide"), "Side wrongSide is not valid")
 
-	assert.NoError(t, mcw.SolveConflict(0, "rightSide"))
+	assert.NoError(t, mcw.SolveConflict("1", "rightSide"))
 	assert.Equal(t,
 		merger.MergeSolution{
 			Side:      merger.RightSide,
@@ -244,11 +193,9 @@ func TestMergeConflictsWrapper_SolveConflict(t *testing.T) {
 			Discarded: mcw.conflicts["1"].Left,
 		},
 		mcw.solutions["1"])
-	assert.Equal(t, 1, mcw.GetNextConflictIndex())
-	assert.NoError(t, mcw.SolveConflict(0, "rightSide"))
-	assert.Equal(t, 1, mcw.GetNextConflictIndex())
+	assert.EqualError(t, mcw.SolveConflict("1", "rightSide"), "Unsolved conflict with key 1 does not exist")
 
-	assert.NoError(t, mcw.SolveConflict(1, "leftSide"))
+	assert.NoError(t, mcw.SolveConflict("2", "leftSide"))
 	assert.Equal(t,
 		merger.MergeSolution{
 			Side:      merger.LeftSide,
@@ -256,19 +203,8 @@ func TestMergeConflictsWrapper_SolveConflict(t *testing.T) {
 			Discarded: mcw.conflicts["2"].Right,
 		},
 		mcw.solutions["2"])
-	assert.Equal(t, 2, mcw.GetNextConflictIndex())
 
-	assert.NoError(t, mcw.SolveConflict(2, "leftSide"))
-	assert.Equal(t, -1, mcw.GetNextConflictIndex())
-
-	// Change previous solution to different one
-	assert.NoError(t, mcw.SolveConflict(0, "leftSide"))
-	assert.Equal(t,
-		merger.MergeSolution{
-			Side:      merger.LeftSide,
-			Solution:  mcw.conflicts["1"].Left,
-			Discarded: mcw.conflicts["1"].Right,
-		},
-		mcw.solutions["1"])
-	assert.Equal(t, -1, mcw.GetNextConflictIndex())
+	assert.Empty(t, mcw.unsolvedConflicts)
+	_, err := mcw.NextConflict()
+	assert.EqualError(t, err, "There are no unsolved conflicts")
 }

--- a/gomobile/Merge_test.go
+++ b/gomobile/Merge_test.go
@@ -132,8 +132,12 @@ func Test_MergeWithAutoresolution(t *testing.T) {
 }
 
 func selectSameSide(mcw *MergeConflictsWrapper, side string) {
-	for i := mcw.GetNextConflictIndex(); i != -1; i = mcw.GetNextConflictIndex() {
-		mcw.SolveConflict(i, side)
+	for {
+		conflict, err := mcw.NextConflict()
+		if err != nil {
+			break
+		}
+		mcw.SolveConflict(conflict.Key, side)
 	}
 }
 

--- a/merger/TagMapMerger.go
+++ b/merger/TagMapMerger.go
@@ -10,6 +10,10 @@ import (
 // removes redundant entries and also makes sure that the position-order
 // stays similar.
 func MergeTagMaps(left []*model.TagMap, right []*model.TagMap, conflictSolution map[string]MergeSolution) ([]*model.TagMap, IDChanges, error) {
+	if len(left)+len(right) == 0 {
+		return nil, IDChanges{}, nil
+	}
+
 	// map[TagID]map[UniqueKey]TagMap
 	tags := make(map[int]map[string]*model.TagMap, len(left)+len(right))
 

--- a/merger/TagMapMerger_test.go
+++ b/merger/TagMapMerger_test.go
@@ -280,4 +280,9 @@ func TestMergeTagMaps(t *testing.T) {
 	// Check if original has not been tweaked
 	assert.Equal(t, 12, left[11].TagMapID)
 	assert.Equal(t, 8, right[7].TagMapID)
+
+	assert.NotPanics(t, func() {
+		MergeTagMaps(nil, nil, nil)
+		MergeTagMaps([]*model.TagMap{}, []*model.TagMap{}, nil)
+	})
 }

--- a/merger/UserMarkBlockRangeMerger_test.go
+++ b/merger/UserMarkBlockRangeMerger_test.go
@@ -828,7 +828,7 @@ func TestMergeUserMarkAndBlockRange_with_conflict1(t *testing.T) {
 	assert.Equal(t, expectedChanges, changes)
 }
 
-func TestMergeUserMarkAndBlockRange_with_conflict(t *testing.T) {
+func TestMergeUserMarkAndBlockRange_with_conflict2(t *testing.T) {
 	left := []*model.UserMarkBlockRange{
 		nil,
 		{

--- a/merger/UserMarkBlockRangeMerger_test.go
+++ b/merger/UserMarkBlockRangeMerger_test.go
@@ -227,7 +227,249 @@ func TestMergeUserMarkAndBlockRange_without_conflict(t *testing.T) {
 	assert.Equal(t, 4, leftBR[4].BlockRangeID)
 }
 
-func TestMergeUserMarkAndBlockRange_with_conflict(t *testing.T) {
+func Test_MergeUserMarkAndBlockRange_without_conflict2(t *testing.T) {
+	// Merge without conflict
+	left := []*model.UserMarkBlockRange{
+		nil,
+		{
+			UserMark: &model.UserMark{
+				UserMarkID: 1,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 1,
+					UserMarkID:   1,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{0, true},
+					EndToken:     sql.NullInt32{0, true},
+				},
+			},
+		},
+		{
+			UserMark: &model.UserMark{
+				UserMarkID: 2,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 1,
+					UserMarkID:   2,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{1, true},
+					EndToken:     sql.NullInt32{1, true},
+				},
+			},
+		},
+	}
+
+	right := []*model.UserMarkBlockRange{
+		nil,
+		{
+			UserMark: &model.UserMark{
+				UserMarkID: 1,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 1,
+					UserMarkID:   1,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{0, true},
+					EndToken:     sql.NullInt32{0, true},
+				},
+			},
+		},
+		{
+			UserMark: &model.UserMark{
+				UserMarkID: 2,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 1,
+					UserMarkID:   2,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{1, true},
+					EndToken:     sql.NullInt32{1, true},
+				},
+			},
+		},
+	}
+
+	expectedResult := []*model.UserMarkBlockRange{
+		nil,
+		{
+			UserMark: &model.UserMark{
+				UserMarkID: 1,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 1,
+					UserMarkID:   1,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{0, true},
+					EndToken:     sql.NullInt32{0, true},
+				},
+			},
+		},
+		{
+			UserMark: &model.UserMark{
+				UserMarkID: 2,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 2,
+					UserMarkID:   2,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{1, true},
+					EndToken:     sql.NullInt32{1, true},
+				},
+			},
+		},
+	}
+	expectedChanges := IDChanges{
+		Left: map[int]int{},
+		Right: map[int]int{
+			1: 1,
+			2: 2,
+		},
+	}
+
+	leftUm, leftBr := splitUserMarkBlockRange(left)
+	rightUm, rightBr := splitUserMarkBlockRange(right)
+
+	resUm, resBr, changes, err := MergeUserMarkAndBlockRange(leftUm, leftBr, rightUm, rightBr, nil)
+	result := joinToUserMarkBlockRange(resUm, resBr)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResult, result)
+	assert.Equal(t, expectedChanges, changes)
+}
+
+func Test_MergeUserMarkAndBlockRange_without_conflict3(t *testing.T) {
+	// Merge without conflict
+	left := []*model.UserMarkBlockRange{
+		nil,
+		{
+			UserMark: &model.UserMark{
+				UserMarkID: 1,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 1,
+					UserMarkID:   1,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{0, true},
+					EndToken:     sql.NullInt32{0, true},
+				},
+			},
+		},
+		{
+			UserMark: &model.UserMark{
+				UserMarkID: 2,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 1,
+					UserMarkID:   2,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{0, true},
+					EndToken:     sql.NullInt32{1, true},
+				},
+			},
+		},
+	}
+
+	right := []*model.UserMarkBlockRange{
+		nil,
+		{
+			UserMark: &model.UserMark{
+				UserMarkID: 1,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 1,
+					UserMarkID:   1,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{0, true},
+					EndToken:     sql.NullInt32{0, true},
+				},
+			},
+		},
+		{
+			UserMark: &model.UserMark{
+				UserMarkID: 2,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 1,
+					UserMarkID:   2,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{0, true},
+					EndToken:     sql.NullInt32{1, true},
+				},
+			},
+		},
+	}
+
+	expectedResult := []*model.UserMarkBlockRange{
+		nil,
+		{
+			UserMark: &model.UserMark{
+				UserMarkID: 1,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 1,
+					UserMarkID:   1,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{0, true},
+					EndToken:     sql.NullInt32{0, true},
+				},
+			},
+		},
+		{
+			UserMark: &model.UserMark{
+				UserMarkID: 2,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 2,
+					UserMarkID:   2,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{0, true},
+					EndToken:     sql.NullInt32{1, true},
+				},
+			},
+		},
+	}
+	expectedChanges := IDChanges{
+		Left: map[int]int{},
+		Right: map[int]int{
+			1: 1,
+			2: 2,
+		},
+	}
+
+	leftUm, leftBr := splitUserMarkBlockRange(left)
+	rightUm, rightBr := splitUserMarkBlockRange(right)
+
+	resUm, resBr, changes, err := MergeUserMarkAndBlockRange(leftUm, leftBr, rightUm, rightBr, nil)
+	result := joinToUserMarkBlockRange(resUm, resBr)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResult, result)
+	assert.Equal(t, expectedChanges, changes)
+}
+
+func TestMergeUserMarkAndBlockRange_with_conflict1(t *testing.T) {
 	// Try merge and find conflict
 	leftUM := []*model.UserMark{
 		nil,
@@ -586,7 +828,415 @@ func TestMergeUserMarkAndBlockRange_with_conflict(t *testing.T) {
 	assert.Equal(t, expectedChanges, changes)
 }
 
-func Test_mergeUserMarkBlockRange_without_conflict(t *testing.T) {
+func TestMergeUserMarkAndBlockRange_with_conflict(t *testing.T) {
+	left := []*model.UserMarkBlockRange{
+		nil,
+		{
+			UserMark: &model.UserMark{
+				UserMarkID: 1,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 1,
+					UserMarkID:   1,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{0, true},
+					EndToken:     sql.NullInt32{0, true},
+				},
+			},
+		},
+		{
+			UserMark: &model.UserMark{
+				UserMarkID: 2,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 2,
+					UserMarkID:   2,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{1, true},
+					EndToken:     sql.NullInt32{1, true},
+				},
+			},
+		},
+		{
+			UserMark: &model.UserMark{
+				UserMarkID: 3,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 3,
+					UserMarkID:   3,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{2, true},
+					EndToken:     sql.NullInt32{2, true},
+				},
+			},
+		},
+		{
+			UserMark: &model.UserMark{
+				UserMarkID: 4,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 4,
+					UserMarkID:   4,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{3, true},
+					EndToken:     sql.NullInt32{3, true},
+				},
+			},
+		},
+	}
+
+	right := []*model.UserMarkBlockRange{
+		nil,
+		{
+			UserMark: &model.UserMark{
+				UserMarkID: 1,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 1,
+					UserMarkID:   1,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{0, true},
+					EndToken:     sql.NullInt32{20, true},
+				},
+			},
+		},
+	}
+
+	expectedConflicts := []MergeConflict{
+		{
+			Left: &model.UserMarkBlockRange{
+				UserMark: &model.UserMark{
+					UserMarkID: 1,
+					LocationID: 1,
+				},
+				BlockRanges: []*model.BlockRange{
+					{
+						BlockRangeID: 1,
+						UserMarkID:   1,
+						Identifier:   1,
+						StartToken:   sql.NullInt32{0, true},
+						EndToken:     sql.NullInt32{0, true},
+					},
+				},
+			},
+			Right: &model.UserMarkBlockRange{
+				UserMark: &model.UserMark{
+					UserMarkID: 1,
+					LocationID: 1,
+				},
+				BlockRanges: []*model.BlockRange{
+					{
+						BlockRangeID: 1,
+						UserMarkID:   1,
+						Identifier:   1,
+						StartToken:   sql.NullInt32{0, true},
+						EndToken:     sql.NullInt32{20, true},
+					},
+				},
+			},
+		},
+	}
+	leftUM, leftBR := splitUserMarkBlockRange(left)
+	rightUM, rightBR := splitUserMarkBlockRange(right)
+
+	resultUM, resultBR, _, err := MergeUserMarkAndBlockRange(leftUM, leftBR, rightUM, rightBR, nil)
+	conflictResult := mergeConflictMapToSliceHelper(err.(MergeConflictError).Conflicts)
+	assert.Empty(t, resultUM)
+	assert.Empty(t, resultBR)
+	assert.Error(t, err)
+	assert.Equal(t, expectedConflicts, conflictResult)
+
+	conflictSolution := map[string]MergeSolution{
+		"0": {
+			Side: RightSide,
+			Solution: &model.UserMarkBlockRange{
+				UserMark: &model.UserMark{
+					UserMarkID: 1,
+					LocationID: 1,
+				},
+				BlockRanges: []*model.BlockRange{
+					{
+						BlockRangeID: 1,
+						UserMarkID:   1,
+						Identifier:   1,
+						StartToken:   sql.NullInt32{0, true},
+						EndToken:     sql.NullInt32{20, true},
+					},
+				},
+			},
+			Discarded: &model.UserMarkBlockRange{
+				UserMark: &model.UserMark{
+					UserMarkID: 1,
+					LocationID: 1,
+				},
+				BlockRanges: []*model.BlockRange{
+					{
+						BlockRangeID: 1,
+						UserMarkID:   1,
+						Identifier:   1,
+						StartToken:   sql.NullInt32{0, true},
+						EndToken:     sql.NullInt32{0, true},
+					},
+				},
+			},
+		},
+	}
+
+	expectedConflicts = []MergeConflict{
+		{
+			Left: &model.UserMarkBlockRange{
+				UserMark: &model.UserMark{
+					UserMarkID: 2,
+					LocationID: 1,
+				},
+				BlockRanges: []*model.BlockRange{
+					{
+						BlockRangeID: 2,
+						UserMarkID:   2,
+						Identifier:   1,
+						StartToken:   sql.NullInt32{1, true},
+						EndToken:     sql.NullInt32{1, true},
+					},
+				},
+			},
+			Right: &model.UserMarkBlockRange{
+				UserMark: &model.UserMark{
+					UserMarkID: 1,
+					LocationID: 1,
+				},
+				BlockRanges: []*model.BlockRange{
+					{
+						BlockRangeID: 1,
+						UserMarkID:   1,
+						Identifier:   1,
+						StartToken:   sql.NullInt32{0, true},
+						EndToken:     sql.NullInt32{20, true},
+					},
+				},
+			},
+		},
+	}
+
+	leftUM, leftBR = splitUserMarkBlockRange(left)
+	rightUM, rightBR = splitUserMarkBlockRange(right)
+	resultUM, resultBR, _, err = MergeUserMarkAndBlockRange(leftUM, leftBR, rightUM, rightBR, conflictSolution)
+	conflictResult = mergeConflictMapToSliceHelper(err.(MergeConflictError).Conflicts)
+	assert.Empty(t, resultUM)
+	assert.Empty(t, resultBR)
+	assert.Error(t, err)
+	assert.Equal(t, expectedConflicts, conflictResult)
+
+	conflictSolution["2"] = MergeSolution{
+		Side: RightSide,
+		Solution: &model.UserMarkBlockRange{
+			UserMark: &model.UserMark{
+				UserMarkID: 1,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 1,
+					UserMarkID:   1,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{0, true},
+					EndToken:     sql.NullInt32{20, true},
+				},
+			},
+		},
+		Discarded: &model.UserMarkBlockRange{
+			UserMark: &model.UserMark{
+				UserMarkID: 2,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 2,
+					UserMarkID:   2,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{1, true},
+					EndToken:     sql.NullInt32{1, true},
+				},
+			},
+		},
+	}
+
+	expectedConflicts = []MergeConflict{
+		{
+			Left: &model.UserMarkBlockRange{
+				UserMark: &model.UserMark{
+					UserMarkID: 3,
+					LocationID: 1,
+				},
+				BlockRanges: []*model.BlockRange{
+					{
+						BlockRangeID: 3,
+						UserMarkID:   3,
+						Identifier:   1,
+						StartToken:   sql.NullInt32{2, true},
+						EndToken:     sql.NullInt32{2, true},
+					},
+				},
+			},
+			Right: &model.UserMarkBlockRange{
+				UserMark: &model.UserMark{
+					UserMarkID: 1,
+					LocationID: 1,
+				},
+				BlockRanges: []*model.BlockRange{
+					{
+						BlockRangeID: 1,
+						UserMarkID:   1,
+						Identifier:   1,
+						StartToken:   sql.NullInt32{0, true},
+						EndToken:     sql.NullInt32{20, true},
+					},
+				},
+			},
+		},
+	}
+
+	leftUM, leftBR = splitUserMarkBlockRange(left)
+	rightUM, rightBR = splitUserMarkBlockRange(right)
+	resultUM, resultBR, _, err = MergeUserMarkAndBlockRange(leftUM, leftBR, rightUM, rightBR, conflictSolution)
+	conflictResult = mergeConflictMapToSliceHelper(err.(MergeConflictError).Conflicts)
+	assert.Empty(t, resultUM)
+	assert.Empty(t, resultBR)
+	assert.Error(t, err)
+	assert.Equal(t, expectedConflicts, conflictResult)
+
+	conflictSolution["3"] = MergeSolution{
+		Side: RightSide,
+		Solution: &model.UserMarkBlockRange{
+			UserMark: &model.UserMark{
+				UserMarkID: 1,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 1,
+					UserMarkID:   1,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{0, true},
+					EndToken:     sql.NullInt32{20, true},
+				},
+			},
+		},
+		Discarded: &model.UserMarkBlockRange{
+			UserMark: &model.UserMark{
+				UserMarkID: 3,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 3,
+					UserMarkID:   3,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{2, true},
+					EndToken:     sql.NullInt32{2, true},
+				},
+			},
+		},
+	}
+
+	expectedConflicts = []MergeConflict{
+		{
+			Left: &model.UserMarkBlockRange{
+				UserMark: &model.UserMark{
+					UserMarkID: 4,
+					LocationID: 1,
+				},
+				BlockRanges: []*model.BlockRange{
+					{
+						BlockRangeID: 4,
+						UserMarkID:   4,
+						Identifier:   1,
+						StartToken:   sql.NullInt32{3, true},
+						EndToken:     sql.NullInt32{3, true},
+					},
+				},
+			},
+			Right: &model.UserMarkBlockRange{
+				UserMark: &model.UserMark{
+					UserMarkID: 1,
+					LocationID: 1,
+				},
+				BlockRanges: []*model.BlockRange{
+					{
+						BlockRangeID: 1,
+						UserMarkID:   1,
+						Identifier:   1,
+						StartToken:   sql.NullInt32{0, true},
+						EndToken:     sql.NullInt32{20, true},
+					},
+				},
+			},
+		},
+	}
+
+	leftUM, leftBR = splitUserMarkBlockRange(left)
+	rightUM, rightBR = splitUserMarkBlockRange(right)
+	resultUM, resultBR, _, err = MergeUserMarkAndBlockRange(leftUM, leftBR, rightUM, rightBR, conflictSolution)
+	conflictResult = mergeConflictMapToSliceHelper(err.(MergeConflictError).Conflicts)
+	assert.Empty(t, resultUM)
+	assert.Empty(t, resultBR)
+	assert.Error(t, err)
+	assert.Equal(t, expectedConflicts, conflictResult)
+
+	conflictSolution["4"] = MergeSolution{
+		Side: RightSide,
+		Solution: &model.UserMarkBlockRange{
+			UserMark: &model.UserMark{
+				UserMarkID: 1,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 1,
+					UserMarkID:   1,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{0, true},
+					EndToken:     sql.NullInt32{20, true},
+				},
+			},
+		},
+		Discarded: &model.UserMarkBlockRange{
+			UserMark: &model.UserMark{
+				UserMarkID: 4,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 4,
+					UserMarkID:   4,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{3, true},
+					EndToken:     sql.NullInt32{3, true},
+				},
+			},
+		},
+	}
+
+	expectedUM, expectedBR := splitUserMarkBlockRange(right)
+
+	leftUM, leftBR = splitUserMarkBlockRange(left)
+	rightUM, rightBR = splitUserMarkBlockRange(right)
+	resultUM, resultBR, _, err = MergeUserMarkAndBlockRange(leftUM, leftBR, rightUM, rightBR, conflictSolution)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedUM, resultUM)
+	assert.Equal(t, expectedBR, resultBR)
+}
+
+func Test_mergeUMBR_without_conflict1(t *testing.T) {
 	// Merge without conflict
 	left := []*model.UserMarkBlockRange{
 		nil,
@@ -781,7 +1431,7 @@ func Test_mergeUserMarkBlockRange_without_conflict(t *testing.T) {
 	assert.Equal(t, expectedChanges, changes)
 }
 
-func Test_mergeUserMarkBlockRange_with_conflict(t *testing.T) {
+func Test_mergeUMBR_with_conflict(t *testing.T) {
 	// Try merge and find conflict
 	left := []*model.UserMarkBlockRange{
 		nil,
@@ -1160,6 +1810,517 @@ func Test_mergeUserMarkBlockRange_with_conflict(t *testing.T) {
 			1: 4,
 			3: 5,
 			4: 1,
+		},
+	}
+
+	result, changes, err := mergeUMBR(left, right, conflictSolution)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResult, result)
+	assert.Equal(t, expectedChanges, changes)
+}
+
+func Test_mergeUMBR_with_multi_conflict_1(t *testing.T) {
+	// Try merge and find conflict
+	left := []*model.UserMarkBlockRange{
+		nil,
+		{
+			UserMark: &model.UserMark{
+				UserMarkID: 1,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 1,
+					UserMarkID:   1,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{0, true},
+					EndToken:     sql.NullInt32{0, true},
+				},
+			},
+		},
+		{
+			UserMark: &model.UserMark{
+				UserMarkID: 2,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 2,
+					UserMarkID:   2,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{1, true},
+					EndToken:     sql.NullInt32{1, true},
+				},
+			},
+		},
+	}
+
+	right := []*model.UserMarkBlockRange{
+		nil,
+		{
+			UserMark: &model.UserMark{
+				UserMarkID: 1,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 1,
+					UserMarkID:   1,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{0, true},
+					EndToken:     sql.NullInt32{20, true},
+				},
+			},
+		},
+	}
+
+	expectedConflicts := []MergeConflict{
+		{
+			Left: &model.UserMarkBlockRange{
+				UserMark: &model.UserMark{
+					UserMarkID: 1,
+					LocationID: 1,
+				},
+				BlockRanges: []*model.BlockRange{
+					{
+						BlockRangeID: 1,
+						UserMarkID:   1,
+						Identifier:   1,
+						StartToken:   sql.NullInt32{0, true},
+						EndToken:     sql.NullInt32{0, true},
+					},
+				},
+			},
+			Right: &model.UserMarkBlockRange{
+				UserMark: &model.UserMark{
+					UserMarkID: 1,
+					LocationID: 1,
+				},
+				BlockRanges: []*model.BlockRange{
+					{
+						BlockRangeID: 1,
+						UserMarkID:   1,
+						Identifier:   1,
+						StartToken:   sql.NullInt32{0, true},
+						EndToken:     sql.NullInt32{20, true},
+					},
+				},
+			},
+		},
+	}
+
+	result, _, err := mergeUMBR(left, right, nil)
+	conflictResult := mergeConflictMapToSliceHelper(err.(MergeConflictError).Conflicts)
+	assert.Empty(t, result)
+	assert.Error(t, err)
+	assert.Equal(t, expectedConflicts, conflictResult)
+
+	conflictSolution := map[string]MergeSolution{
+		"0": {
+			Side: RightSide,
+			Solution: &model.UserMarkBlockRange{
+				UserMark: &model.UserMark{
+					UserMarkID: 1,
+					LocationID: 1,
+				},
+				BlockRanges: []*model.BlockRange{
+					{
+						BlockRangeID: 1,
+						UserMarkID:   1,
+						Identifier:   1,
+						StartToken:   sql.NullInt32{0, true},
+						EndToken:     sql.NullInt32{20, true},
+					},
+				},
+			},
+			Discarded: &model.UserMarkBlockRange{
+				UserMark: &model.UserMark{
+					UserMarkID: 1,
+					LocationID: 1,
+				},
+				BlockRanges: []*model.BlockRange{
+					{
+						BlockRangeID: 1,
+						UserMarkID:   1,
+						Identifier:   1,
+						StartToken:   sql.NullInt32{0, true},
+						EndToken:     sql.NullInt32{0, true},
+					},
+				},
+			},
+		},
+	}
+
+	expectedConflicts = []MergeConflict{
+		{
+			Left: &model.UserMarkBlockRange{
+				UserMark: &model.UserMark{
+					UserMarkID: 2,
+					LocationID: 1,
+				},
+				BlockRanges: []*model.BlockRange{
+					{
+						BlockRangeID: 2,
+						UserMarkID:   2,
+						Identifier:   1,
+						StartToken:   sql.NullInt32{1, true},
+						EndToken:     sql.NullInt32{1, true},
+					},
+				},
+			},
+			Right: &model.UserMarkBlockRange{
+				UserMark: &model.UserMark{
+					UserMarkID: 1,
+					LocationID: 1,
+				},
+				BlockRanges: []*model.BlockRange{
+					{
+						BlockRangeID: 1,
+						UserMarkID:   1,
+						Identifier:   1,
+						StartToken:   sql.NullInt32{0, true},
+						EndToken:     sql.NullInt32{20, true},
+					},
+				},
+			},
+		},
+	}
+
+	result, _, err = mergeUMBR(left, right, conflictSolution)
+	conflictResult = mergeConflictMapToSliceHelper(err.(MergeConflictError).Conflicts)
+	assert.Empty(t, result)
+	assert.Error(t, err)
+	assert.Equal(t, expectedConflicts, conflictResult)
+
+	conflictSolution = map[string]MergeSolution{
+		"0": {
+			Side: RightSide,
+			Solution: &model.UserMarkBlockRange{
+				UserMark: &model.UserMark{
+					UserMarkID: 1,
+					LocationID: 1,
+				},
+				BlockRanges: []*model.BlockRange{
+					{
+						BlockRangeID: 1,
+						UserMarkID:   1,
+						Identifier:   1,
+						StartToken:   sql.NullInt32{0, true},
+						EndToken:     sql.NullInt32{20, true},
+					},
+				},
+			},
+			Discarded: &model.UserMarkBlockRange{
+				UserMark: &model.UserMark{
+					UserMarkID: 1,
+					LocationID: 1,
+				},
+				BlockRanges: []*model.BlockRange{
+					{
+						BlockRangeID: 1,
+						UserMarkID:   1,
+						Identifier:   1,
+						StartToken:   sql.NullInt32{0, true},
+						EndToken:     sql.NullInt32{0, true},
+					},
+				},
+			},
+		},
+		"1": {
+			Side: RightSide,
+			Solution: &model.UserMarkBlockRange{
+				UserMark: &model.UserMark{
+					UserMarkID: 1,
+					LocationID: 1,
+				},
+				BlockRanges: []*model.BlockRange{
+					{
+						BlockRangeID: 1,
+						UserMarkID:   1,
+						Identifier:   1,
+						StartToken:   sql.NullInt32{0, true},
+						EndToken:     sql.NullInt32{20, true},
+					},
+				},
+			},
+			Discarded: &model.UserMarkBlockRange{
+				UserMark: &model.UserMark{
+					UserMarkID: 2,
+					LocationID: 1,
+				},
+				BlockRanges: []*model.BlockRange{
+					{
+						BlockRangeID: 2,
+						UserMarkID:   2,
+						Identifier:   1,
+						StartToken:   sql.NullInt32{1, true},
+						EndToken:     sql.NullInt32{1, true},
+					},
+				},
+			},
+		},
+	}
+
+	expectedResult := []*model.UserMarkBlockRange{
+		nil,
+		{
+			UserMark: &model.UserMark{
+				UserMarkID: 1,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 1,
+					UserMarkID:   1,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{0, true},
+					EndToken:     sql.NullInt32{20, true},
+				},
+			},
+		},
+	}
+	expectedChanges := IDChanges{
+		Left: map[int]int{
+			1: 1,
+			2: 1,
+		},
+		Right: map[int]int{},
+	}
+
+	result, changes, err := mergeUMBR(left, right, conflictSolution)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResult, result)
+	assert.Equal(t, expectedChanges, changes)
+}
+
+func Test_mergeUMBR_with_multi_conflict_2(t *testing.T) {
+	left := []*model.UserMarkBlockRange{
+		nil,
+		{
+			UserMark: &model.UserMark{
+				UserMarkID: 1,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 1,
+					UserMarkID:   1,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{0, true},
+					EndToken:     sql.NullInt32{0, true},
+				},
+			},
+		},
+		{
+			UserMark: &model.UserMark{
+				UserMarkID: 2,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 2,
+					UserMarkID:   2,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{1, true},
+					EndToken:     sql.NullInt32{1, true},
+				},
+			},
+		},
+		{
+			UserMark: &model.UserMark{
+				UserMarkID: 3,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 3,
+					UserMarkID:   3,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{30, true},
+					EndToken:     sql.NullInt32{31, true},
+				},
+			},
+		},
+		{
+			UserMark: &model.UserMark{
+				UserMarkID: 4,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 4,
+					UserMarkID:   4,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{2, true},
+					EndToken:     sql.NullInt32{2, true},
+				},
+			},
+		},
+	}
+
+	right := []*model.UserMarkBlockRange{
+		nil,
+		{
+			UserMark: &model.UserMark{
+				UserMarkID: 1,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 1,
+					UserMarkID:   1,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{0, true},
+					EndToken:     sql.NullInt32{20, true},
+				},
+			},
+		},
+	}
+
+	expectedConflicts := []MergeConflict{
+		{
+			Left: &model.UserMarkBlockRange{
+				UserMark: &model.UserMark{
+					UserMarkID: 1,
+					LocationID: 1,
+				},
+				BlockRanges: []*model.BlockRange{
+					{
+						BlockRangeID: 1,
+						UserMarkID:   1,
+						Identifier:   1,
+						StartToken:   sql.NullInt32{0, true},
+						EndToken:     sql.NullInt32{0, true},
+					},
+				},
+			},
+			Right: &model.UserMarkBlockRange{
+				UserMark: &model.UserMark{
+					UserMarkID: 1,
+					LocationID: 1,
+				},
+				BlockRanges: []*model.BlockRange{
+					{
+						BlockRangeID: 1,
+						UserMarkID:   1,
+						Identifier:   1,
+						StartToken:   sql.NullInt32{0, true},
+						EndToken:     sql.NullInt32{20, true},
+					},
+				},
+			},
+		},
+	}
+
+	result, _, err := mergeUMBR(left, right, nil)
+	conflictResult := mergeConflictMapToSliceHelper(err.(MergeConflictError).Conflicts)
+	assert.Empty(t, result)
+	assert.Error(t, err)
+	assert.Equal(t, expectedConflicts, conflictResult)
+
+	conflictSolution := map[string]MergeSolution{
+		"0": {
+			Side: LeftSide,
+			Solution: &model.UserMarkBlockRange{
+				UserMark: &model.UserMark{
+					UserMarkID: 1,
+					LocationID: 1,
+				},
+				BlockRanges: []*model.BlockRange{
+					{
+						BlockRangeID: 1,
+						UserMarkID:   1,
+						Identifier:   1,
+						StartToken:   sql.NullInt32{0, true},
+						EndToken:     sql.NullInt32{0, true},
+					},
+				},
+			},
+			Discarded: &model.UserMarkBlockRange{
+				UserMark: &model.UserMark{
+					UserMarkID: 1,
+					LocationID: 1,
+				},
+				BlockRanges: []*model.BlockRange{
+					{
+						BlockRangeID: 1,
+						UserMarkID:   1,
+						Identifier:   1,
+						StartToken:   sql.NullInt32{0, true},
+						EndToken:     sql.NullInt32{20, true},
+					},
+				},
+			},
+		},
+	}
+
+	expectedResult := []*model.UserMarkBlockRange{
+		nil,
+		{
+			UserMark: &model.UserMark{
+				UserMarkID: 1,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 1,
+					UserMarkID:   1,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{0, true},
+					EndToken:     sql.NullInt32{0, true},
+				},
+			},
+		},
+		{
+			UserMark: &model.UserMark{
+				UserMarkID: 2,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 2,
+					UserMarkID:   2,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{1, true},
+					EndToken:     sql.NullInt32{1, true},
+				},
+			},
+		},
+		{
+			UserMark: &model.UserMark{
+				UserMarkID: 3,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 3,
+					UserMarkID:   3,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{30, true},
+					EndToken:     sql.NullInt32{31, true},
+				},
+			},
+		},
+		{
+			UserMark: &model.UserMark{
+				UserMarkID: 4,
+				LocationID: 1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					BlockRangeID: 4,
+					UserMarkID:   4,
+					Identifier:   1,
+					StartToken:   sql.NullInt32{2, true},
+					EndToken:     sql.NullInt32{2, true},
+				},
+			},
+		},
+	}
+	expectedChanges := IDChanges{
+		Left: map[int]int{},
+		Right: map[int]int{
+			1: 1,
 		},
 	}
 
@@ -1907,4 +3068,284 @@ func Test_estimateLocationCount(t *testing.T) {
 	assert.Equal(t, 101, estimateLocationCount([]*model.UserMarkBlockRange{{UserMark: &model.UserMark{LocationID: 101}}}, []*model.UserMarkBlockRange{}))
 	assert.Equal(t, 0, estimateLocationCount([]*model.UserMarkBlockRange{}, []*model.UserMarkBlockRange{}))
 	assert.Equal(t, 0, estimateLocationCount([]*model.UserMarkBlockRange{nil}, []*model.UserMarkBlockRange{nil}))
+}
+
+func Test_detectAndFilterDuplicateBRs(t *testing.T) {
+	left := []*model.UserMarkBlockRange{
+		nil,
+		{
+			UserMark: &model.UserMark{
+				UserMarkID:   1,
+				ColorIndex:   1,
+				LocationID:   1,
+				StyleIndex:   1,
+				UserMarkGUID: "FirstDuplicate",
+				Version:      1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					UserMarkID: 1,
+					StartToken: sql.NullInt32{0, true},
+					EndToken:   sql.NullInt32{0, true},
+				},
+			},
+		},
+		{
+			UserMark: &model.UserMark{
+				UserMarkID:   2,
+				ColorIndex:   2,
+				LocationID:   2,
+				StyleIndex:   2,
+				UserMarkGUID: "SecondDuplicate",
+				Version:      1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					UserMarkID: 2,
+					StartToken: sql.NullInt32{1, true},
+					EndToken:   sql.NullInt32{2, true},
+				},
+			},
+		},
+	}
+	right := left
+
+	idBlock := []brFrom{
+		{},
+		{
+			side: RightSide,
+			br: &model.BlockRange{
+				StartToken: sql.NullInt32{4, true},
+				EndToken:   sql.NullInt32{5, true},
+			},
+		},
+		{
+			side: LeftSide,
+			br: &model.BlockRange{
+				UserMarkID: 2,
+				StartToken: sql.NullInt32{1, true},
+				EndToken:   sql.NullInt32{2, true},
+			},
+		},
+		{
+			side: LeftSide,
+			br: &model.BlockRange{
+				UserMarkID: 1,
+				StartToken: sql.NullInt32{0, true},
+				EndToken:   sql.NullInt32{0, true},
+			},
+		},
+		{
+			side: LeftSide,
+			br: &model.BlockRange{
+				StartToken: sql.NullInt32{0, true},
+				EndToken:   sql.NullInt32{1, true},
+			},
+		},
+		{
+			side: RightSide,
+			br: &model.BlockRange{
+				UserMarkID: 1,
+				StartToken: sql.NullInt32{0, true},
+				EndToken:   sql.NullInt32{0, true},
+			},
+		},
+		{
+			side: RightSide,
+			br: &model.BlockRange{
+				UserMarkID: 2,
+				StartToken: sql.NullInt32{1, true},
+				EndToken:   sql.NullInt32{2, true},
+			},
+		},
+	}
+
+	expectedIDBlocks := []brFrom{
+		{
+			side: LeftSide,
+			br: &model.BlockRange{
+				UserMarkID: 1,
+				StartToken: sql.NullInt32{0, true},
+				EndToken:   sql.NullInt32{0, true},
+			},
+		},
+		{
+			side: LeftSide,
+			br: &model.BlockRange{
+				StartToken: sql.NullInt32{0, true},
+				EndToken:   sql.NullInt32{1, true},
+			},
+		},
+		{
+			side: LeftSide,
+			br: &model.BlockRange{
+				UserMarkID: 2,
+				StartToken: sql.NullInt32{1, true},
+				EndToken:   sql.NullInt32{2, true},
+			},
+		},
+		{
+			side: RightSide,
+			br: &model.BlockRange{
+				StartToken: sql.NullInt32{4, true},
+				EndToken:   sql.NullInt32{5, true},
+			},
+		},
+	}
+	expectedCollisions := map[string]MergeConflict{
+		"FirstDuplicate_0_0_0_0_1_FirstDuplicate_0_0_0_0_1": {
+			Left: &model.UserMarkBlockRange{
+				UserMark: &model.UserMark{
+					UserMarkID:   1,
+					ColorIndex:   1,
+					LocationID:   1,
+					StyleIndex:   1,
+					UserMarkGUID: "FirstDuplicate",
+					Version:      1,
+				},
+				BlockRanges: []*model.BlockRange{
+					{
+						UserMarkID: 1,
+						StartToken: sql.NullInt32{0, true},
+						EndToken:   sql.NullInt32{0, true},
+					},
+				},
+			},
+			Right: &model.UserMarkBlockRange{
+				UserMark: &model.UserMark{
+					UserMarkID:   1,
+					ColorIndex:   1,
+					LocationID:   1,
+					StyleIndex:   1,
+					UserMarkGUID: "FirstDuplicate",
+					Version:      1,
+				},
+				BlockRanges: []*model.BlockRange{
+					{
+						UserMarkID: 1,
+						StartToken: sql.NullInt32{0, true},
+						EndToken:   sql.NullInt32{0, true},
+					},
+				},
+			},
+		},
+		"SecondDuplicate_0_0_1_2_2_SecondDuplicate_0_0_1_2_2": {
+			Left: &model.UserMarkBlockRange{
+				UserMark: &model.UserMark{
+					UserMarkID:   2,
+					ColorIndex:   2,
+					LocationID:   2,
+					StyleIndex:   2,
+					UserMarkGUID: "SecondDuplicate",
+					Version:      1,
+				},
+				BlockRanges: []*model.BlockRange{
+					{
+						UserMarkID: 2,
+						StartToken: sql.NullInt32{1, true},
+						EndToken:   sql.NullInt32{2, true},
+					},
+				},
+			},
+			Right: &model.UserMarkBlockRange{
+				UserMark: &model.UserMark{
+					UserMarkID:   2,
+					ColorIndex:   2,
+					LocationID:   2,
+					StyleIndex:   2,
+					UserMarkGUID: "SecondDuplicate",
+					Version:      1,
+				},
+				BlockRanges: []*model.BlockRange{
+					{
+						UserMarkID: 2,
+						StartToken: sql.NullInt32{1, true},
+						EndToken:   sql.NullInt32{2, true},
+					},
+				},
+			},
+		},
+	}
+
+	idBlockResult, collisionsResult := detectAndFilterDuplicateBRs(idBlock, left, right)
+	assert.Equal(t, expectedIDBlocks, idBlockResult)
+	assert.Equal(t, expectedCollisions, collisionsResult)
+}
+
+func Test_sortBRFroms(t *testing.T) {
+	entries := []brFrom{
+		{},
+		{
+			br: &model.BlockRange{
+				StartToken: sql.NullInt32{1, true},
+				EndToken:   sql.NullInt32{2, true},
+			},
+		},
+		{
+			side: "",
+			br:   nil,
+		},
+		{
+			br: &model.BlockRange{
+				StartToken: sql.NullInt32{0, true},
+				EndToken:   sql.NullInt32{0, true},
+			},
+		},
+		{
+			br: &model.BlockRange{
+				StartToken: sql.NullInt32{4, true},
+				EndToken:   sql.NullInt32{5, true},
+			},
+		},
+		{
+			br: &model.BlockRange{
+				StartToken: sql.NullInt32{0, true},
+				EndToken:   sql.NullInt32{0, true},
+			},
+		},
+		{},
+		{},
+		{
+			br: &model.BlockRange{
+				StartToken: sql.NullInt32{1, true},
+				EndToken:   sql.NullInt32{4, true},
+			},
+		},
+		{},
+	}
+
+	expectedResult := []brFrom{
+		{
+			br: &model.BlockRange{
+				StartToken: sql.NullInt32{0, true},
+				EndToken:   sql.NullInt32{0, true},
+			},
+		},
+		{
+			br: &model.BlockRange{
+				StartToken: sql.NullInt32{0, true},
+				EndToken:   sql.NullInt32{0, true},
+			},
+		},
+		{
+			br: &model.BlockRange{
+				StartToken: sql.NullInt32{1, true},
+				EndToken:   sql.NullInt32{2, true},
+			},
+		},
+		{
+			br: &model.BlockRange{
+				StartToken: sql.NullInt32{1, true},
+				EndToken:   sql.NullInt32{4, true},
+			},
+		},
+		{
+			br: &model.BlockRange{
+				StartToken: sql.NullInt32{4, true},
+				EndToken:   sql.NullInt32{5, true},
+			},
+		},
+	}
+
+	assert.Equal(t, expectedResult, sortBRFroms(entries))
 }

--- a/model/Database_test.go
+++ b/model/Database_test.go
@@ -289,12 +289,10 @@ func TestDatabase_saveToNewSQLite(t *testing.T) {
 		UserMark:   []*UserMark{{2, 1, 2, 0, "2C5E7B4A-4997-4EDA-9CFF-38A7599C487B", 1}},
 	}
 	path := filepath.Join(tmp, "user_data.db")
-	err = db.saveToNewSQLite(path)
-	assert.NoError(t, err)
+	assert.NoError(t, db.saveToNewSQLite(path))
 
 	db2 := Database{}
-	err = db2.importSQLite(path)
-	assert.NoError(t, err)
+	assert.NoError(t, db2.importSQLite(path))
 
 	assert.Equal(t, db.BlockRange[0], db2.BlockRange[3])
 	assert.Equal(t, db.Bookmark[0], db2.Bookmark[2])
@@ -302,6 +300,13 @@ func TestDatabase_saveToNewSQLite(t *testing.T) {
 	assert.Equal(t, db.Note[0], db2.Note[2])
 	assert.Equal(t, db.TagMap[0], db2.TagMap[2])
 	assert.Equal(t, db.UserMark[0], db2.UserMark[2])
+
+	// Check if saving empty tables is possible
+	db = Database{
+		BlockRange: []*BlockRange{{3, 2, 13, sql.NullInt32{Int32: 0, Valid: true}, sql.NullInt32{Int32: 14, Valid: true}, 3}},
+		Bookmark:   []*Bookmark{nil},
+	}
+	assert.NoError(t, db.saveToNewSQLite(path))
 }
 
 func TestDatabase_Equals(t *testing.T) {


### PR DESCRIPTION
**🐛 Fix problem when merging markings**
If on one side there were multiple blockRanges that collided with the same blockRange on the other side, the merger counted all of these collisions immediately. This resulted in infinite mergeConflicts and other strange behavior. 
Improved the merging of markings so when there are multiple collisions with the same blockRange, only the first one gets noted, while the others are skipped until the next iteration. Either they have by then been automatically solved (because the one blockRange was not chosen) or the next conflict gets detected. Updated the merge cmd so its able to handle multiple conflict handling runs. 

**✨ Simplify mobile wrapper for handling merge conflicts**
Instead of working with an index of conflicts, which is complicated and does not work with the mentioned bugfix, we now just have two functions:
* `NextConflict`: returns a conflict that still needs to be solved
* `SolveConflict`: solves a conflict, which is represented by its key.

**🐛 Other bug fixes**
* Don't fail when saving empty tables
* Apply umbrConflictSolution in right order 
* Don't panic with empty tagMap slices 

✅ Added more test cases
