### PR TITLE
:bug: Fix problems when detecting marking duplicates

### DIFF
--- a/merger/UserMarkBlockRangeMerger.go
+++ b/merger/UserMarkBlockRangeMerger.go
@@ -213,7 +213,14 @@ func detectAndFilterDuplicateBRs(idBlock []brFrom, left []*model.UserMarkBlockRa
 			if idBlock[j].br.StartToken.Int32 > idBlock[i].br.EndToken.Int32 {
 				break
 			}
-			if idBlock[i].br.Equals(idBlock[j].br) {
+
+			// Check if they equal in all except userMarkID
+			// (BlockRange.Equals checks userMarkID, which we don't want here,
+			// as they obviously can differ between backups..)
+			if idBlock[i].br.BlockType == idBlock[j].br.BlockType &&
+				idBlock[i].br.Identifier == idBlock[j].br.Identifier &&
+				idBlock[i].br.StartToken.Int32 == idBlock[j].br.StartToken.Int32 &&
+				idBlock[i].br.EndToken.Int32 == idBlock[j].br.EndToken.Int32 {
 				// If collision is on the same side, then ignore it
 				// (it's probably not our fault and we hope its okay...)
 				if idBlock[i].side == idBlock[j].side {

--- a/merger/UserMarkBlockRangeMerger.go
+++ b/merger/UserMarkBlockRangeMerger.go
@@ -228,6 +228,12 @@ func detectAndFilterDuplicateBRs(idBlock []brFrom, left []*model.UserMarkBlockRa
 					first = left[idBlock[j].br.UserMarkID]
 					second = right[idBlock[i].br.UserMarkID]
 				}
+
+				// Last check before calling it a duplicate: Are UserMark equal?
+				if !first.UserMark.Equals(second.UserMark) {
+					continue
+				}
+
 				var conflictKey strings.Builder
 				conflictKey.WriteString(first.UniqueKey())
 				conflictKey.WriteString("_")

--- a/merger/UserMarkBlockRangeMerger_test.go
+++ b/merger/UserMarkBlockRangeMerger_test.go
@@ -3070,7 +3070,7 @@ func Test_estimateLocationCount(t *testing.T) {
 	assert.Equal(t, 0, estimateLocationCount([]*model.UserMarkBlockRange{nil}, []*model.UserMarkBlockRange{nil}))
 }
 
-func Test_detectAndFilterDuplicateBRs(t *testing.T) {
+func Test_detectAndFilterDuplicateBRs1(t *testing.T) {
 	left := []*model.UserMarkBlockRange{
 		nil,
 		{
@@ -3270,6 +3270,91 @@ func Test_detectAndFilterDuplicateBRs(t *testing.T) {
 	idBlockResult, collisionsResult := detectAndFilterDuplicateBRs(idBlock, left, right)
 	assert.Equal(t, expectedIDBlocks, idBlockResult)
 	assert.Equal(t, expectedCollisions, collisionsResult)
+}
+
+func Test_detectAndFilterDuplicateBRs2(t *testing.T) {
+	left := []*model.UserMarkBlockRange{
+		nil,
+		{
+			UserMark: &model.UserMark{
+				UserMarkID:   1,
+				ColorIndex:   1,
+				LocationID:   1,
+				StyleIndex:   1,
+				UserMarkGUID: "NotADuplicate",
+				Version:      1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					UserMarkID: 1,
+					StartToken: sql.NullInt32{0, true},
+					EndToken:   sql.NullInt32{0, true},
+				},
+			},
+		},
+	}
+	right := []*model.UserMarkBlockRange{
+		nil,
+		{
+			UserMark: &model.UserMark{
+				UserMarkID:   1,
+				ColorIndex:   2,
+				LocationID:   1,
+				StyleIndex:   1,
+				UserMarkGUID: "NotADuplicate",
+				Version:      1,
+			},
+			BlockRanges: []*model.BlockRange{
+				{
+					UserMarkID: 1,
+					StartToken: sql.NullInt32{0, true},
+					EndToken:   sql.NullInt32{0, true},
+				},
+			},
+		},
+	}
+
+	idBlock := []brFrom{
+		{
+			side: LeftSide,
+			br: &model.BlockRange{
+				UserMarkID: 1,
+				StartToken: sql.NullInt32{0, true},
+				EndToken:   sql.NullInt32{0, true},
+			},
+		},
+		{
+			side: RightSide,
+			br: &model.BlockRange{
+				UserMarkID: 1,
+				StartToken: sql.NullInt32{0, true},
+				EndToken:   sql.NullInt32{0, true},
+			},
+		},
+	}
+
+	expectedIDBlocks := []brFrom{
+		{
+			side: LeftSide,
+			br: &model.BlockRange{
+				UserMarkID: 1,
+				StartToken: sql.NullInt32{0, true},
+				EndToken:   sql.NullInt32{0, true},
+			},
+		},
+		{
+			side: RightSide,
+			br: &model.BlockRange{
+				UserMarkID: 1,
+				StartToken: sql.NullInt32{0, true},
+				EndToken:   sql.NullInt32{0, true},
+			},
+		},
+	}
+
+	idBlockResult, collisionsResult := detectAndFilterDuplicateBRs(idBlock, left, right)
+	assert.Equal(t, expectedIDBlocks, idBlockResult)
+	assert.Empty(t, collisionsResult)
 }
 
 func Test_sortBRFroms(t *testing.T) {


### PR DESCRIPTION
Fixed two bugs both in `detectAndFilterDuplicateBRs`:
* Also check userMark for detecting duplicates: This makes sure that even if the blockRanges are equal, the userMarks that belong to them are equal too (e.g. also the same color etc.). The bug didn't seem to have any noticeable impact.
* Ignore userMarkID when finding duplicates: The userMarkID might be different, even though blockRanges actually ARE equal (which is not true generally, though). This lead to duplicates not being detected, which resulted in infinite loops of solving conflicts..