### PR TITLE
A bunch of (important) bug fixes

### DIFF
--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -85,10 +85,11 @@ func merge(leftFilename string, rightFilename string, mergedFilename string, std
 		case merger.MergeConflictError:
 			if BookmarkResolver != "" {
 				var resErr error
-				bookmarksConflictSolution, resErr = merger.AutoResolveConflicts(err.Conflicts, BookmarkResolver)
+				newSolutions, resErr := merger.AutoResolveConflicts(err.Conflicts, BookmarkResolver)
 				if resErr != nil {
 					log.Fatal(resErr)
 				}
+				addToSolutions(bookmarksConflictSolution, newSolutions)
 			} else {
 				newSolutions := handleMergeConflict(err.Conflicts, &merged, stdio)
 				addToSolutions(bookmarksConflictSolution, newSolutions)
@@ -131,10 +132,11 @@ func merge(leftFilename string, rightFilename string, mergedFilename string, std
 		case merger.MergeConflictError:
 			if MarkingResolver != "" {
 				var resErr error
-				UMBRConflictSolution, resErr = merger.AutoResolveConflicts(err.Conflicts, MarkingResolver)
+				newSolutions, resErr := merger.AutoResolveConflicts(err.Conflicts, MarkingResolver)
 				if resErr != nil {
 					log.Fatal(resErr)
 				}
+				addToSolutions(UMBRConflictSolution, newSolutions)
 			} else {
 				newSolutions := handleMergeConflict(err.Conflicts, &merged, stdio)
 				addToSolutions(UMBRConflictSolution, newSolutions)
@@ -158,10 +160,11 @@ func merge(leftFilename string, rightFilename string, mergedFilename string, std
 		case merger.MergeConflictError:
 			if NoteResolver != "" {
 				var resErr error
-				notesConflictSolution, resErr = merger.AutoResolveConflicts(err.Conflicts, NoteResolver)
+				newSolutions, resErr := merger.AutoResolveConflicts(err.Conflicts, NoteResolver)
 				if resErr != nil {
 					log.Fatal(resErr)
 				}
+				addToSolutions(notesConflictSolution, newSolutions)
 			} else {
 				newSolutions := handleMergeConflict(err.Conflicts, &merged, stdio)
 				addToSolutions(notesConflictSolution, newSolutions)

--- a/gomobile/Merge_test.go
+++ b/gomobile/Merge_test.go
@@ -88,14 +88,33 @@ func Test_MergeMultiCollisionAllExceptOneRight(t *testing.T) {
 		nil,
 		{
 			BlockRangeID: 1,
-			UserMarkID:   1,
+			BlockType:    1,
 			Identifier:   1,
 			StartToken:   sql.NullInt32{3, true},
 			EndToken:     sql.NullInt32{3, true},
+			UserMarkID:   1,
 		},
 	}
 
 	assert.True(t, dbw.merged.Equals(expected))
+}
+
+func Test_MergeMultiCollisionAutoSolver(t *testing.T) {
+	dbw := DatabaseWrapper{
+		left:  model.MakeDatabaseCopy(leftMultiCollision),
+		right: model.MakeDatabaseCopy(rightMultiCollision),
+	}
+	dbw.Init()
+
+	mcw := &MergeConflictsWrapper{}
+	assert.NoError(t, dbw.MergeLocations())
+	assert.NoError(t, dbw.MergeBookmarks("", mcw))
+	assert.NoError(t, dbw.MergeTags())
+	assert.NoError(t, dbw.MergeUserMarkAndBlockRange("chooseRight", mcw))
+	assert.NoError(t, dbw.MergeNotes("", mcw))
+	assert.NoError(t, dbw.MergeTagMaps())
+
+	assert.True(t, dbw.merged.Equals(rightMultiCollision))
 }
 
 var leftMultiCollision = &model.Database{
@@ -103,38 +122,48 @@ var leftMultiCollision = &model.Database{
 		nil,
 		{
 			BlockRangeID: 1,
-			UserMarkID:   1,
+			BlockType:    1,
 			Identifier:   1,
 			StartToken:   sql.NullInt32{0, true},
 			EndToken:     sql.NullInt32{0, true},
+			UserMarkID:   1,
 		},
 		{
 			BlockRangeID: 2,
-			UserMarkID:   2,
+			BlockType:    1,
 			Identifier:   1,
 			StartToken:   sql.NullInt32{1, true},
 			EndToken:     sql.NullInt32{1, true},
+			UserMarkID:   2,
 		},
 		{
 			BlockRangeID: 3,
-			UserMarkID:   3,
+			BlockType:    1,
 			Identifier:   1,
 			StartToken:   sql.NullInt32{2, true},
 			EndToken:     sql.NullInt32{2, true},
+			UserMarkID:   3,
 		},
 		{
 			BlockRangeID: 4,
-			UserMarkID:   4,
+			BlockType:    1,
 			Identifier:   1,
 			StartToken:   sql.NullInt32{3, true},
 			EndToken:     sql.NullInt32{3, true},
+			UserMarkID:   4,
 		},
 	},
 	Bookmark: []*model.Bookmark{nil},
 	Location: []*model.Location{
 		nil,
 		{
-			LocationID: 1,
+			LocationID:    1,
+			BookNumber:    sql.NullInt32{1, true},
+			ChapterNumber: sql.NullInt32{1, true},
+			KeySymbol:     sql.NullString{"nwtsty", true},
+			MepsLanguage:  2,
+			LocationType:  0,
+			Title:         sql.NullString{"1. Mose 1", true},
 		},
 	},
 	Note:   []*model.Note{nil},
@@ -143,20 +172,32 @@ var leftMultiCollision = &model.Database{
 	UserMark: []*model.UserMark{
 		nil,
 		{
-			UserMarkID: 1,
-			LocationID: 1,
+			UserMarkID:   1,
+			ColorIndex:   1,
+			LocationID:   1,
+			StyleIndex:   1,
+			UserMarkGUID: "1",
 		},
 		{
-			UserMarkID: 2,
-			LocationID: 1,
+			UserMarkID:   2,
+			ColorIndex:   1,
+			LocationID:   1,
+			StyleIndex:   1,
+			UserMarkGUID: "2",
 		},
 		{
-			UserMarkID: 3,
-			LocationID: 1,
+			UserMarkID:   3,
+			ColorIndex:   1,
+			LocationID:   1,
+			StyleIndex:   1,
+			UserMarkGUID: "3",
 		},
 		{
-			UserMarkID: 4,
-			LocationID: 1,
+			UserMarkID:   4,
+			ColorIndex:   1,
+			LocationID:   1,
+			StyleIndex:   1,
+			UserMarkGUID: "4",
 		},
 	},
 }
@@ -166,17 +207,24 @@ var rightMultiCollision = &model.Database{
 		nil,
 		{
 			BlockRangeID: 1,
-			UserMarkID:   1,
+			BlockType:    1,
 			Identifier:   1,
 			StartToken:   sql.NullInt32{0, true},
 			EndToken:     sql.NullInt32{20, true},
+			UserMarkID:   1,
 		},
 	},
 	Bookmark: []*model.Bookmark{nil},
 	Location: []*model.Location{
 		nil,
 		{
-			LocationID: 1,
+			LocationID:    1,
+			BookNumber:    sql.NullInt32{1, true},
+			ChapterNumber: sql.NullInt32{1, true},
+			KeySymbol:     sql.NullString{"nwtsty", true},
+			MepsLanguage:  2,
+			LocationType:  0,
+			Title:         sql.NullString{"1. Mose 1", true},
 		},
 	},
 	Note:   []*model.Note{nil},
@@ -185,8 +233,11 @@ var rightMultiCollision = &model.Database{
 	UserMark: []*model.UserMark{
 		nil,
 		{
-			UserMarkID: 1,
-			LocationID: 1,
+			UserMarkID:   1,
+			ColorIndex:   1,
+			LocationID:   1,
+			StyleIndex:   1,
+			UserMarkGUID: "1R",
 		},
 	},
 }

--- a/merger/UserMarkBlockRangeMerger.go
+++ b/merger/UserMarkBlockRangeMerger.go
@@ -49,8 +49,8 @@ func MergeUserMarkAndBlockRange(leftUM []*model.UserMark, leftBR []*model.BlockR
 
 	for {
 		merged, changes, err = mergeUMBR(left, right, conflictSolution)
-		um, br := splitUserMarkBlockRange(merged)
 		if err == nil {
+			um, br := splitUserMarkBlockRange(merged)
 			return um, br, changes, nil
 		}
 

--- a/merger/UserMarkBlockRangeMerger.go
+++ b/merger/UserMarkBlockRangeMerger.go
@@ -59,7 +59,7 @@ func MergeUserMarkAndBlockRange(leftUM []*model.UserMark, leftBR []*model.BlockR
 		case MergeConflictError:
 			autoConflictSolution, sErr := solveEqualityMergeConflict(err.Conflicts)
 			for key, autoSol := range autoConflictSolution {
-				conflictSolution["_"+key] = autoSol
+				conflictSolution[key] = autoSol
 			}
 			if sErr == nil {
 				continue

--- a/merger/UserMarkBlockRangeMerger.go
+++ b/merger/UserMarkBlockRangeMerger.go
@@ -66,7 +66,7 @@ func MergeUserMarkAndBlockRange(leftUM []*model.UserMark, leftBR []*model.BlockR
 			}
 			// If no more conflicts could be solved, fail and return error
 			if reflect.DeepEqual(err.Conflicts, sErr.(MergeConflictError).Conflicts) {
-				return nil, nil, IDChanges{}, err
+				return nil, nil, IDChanges{}, sErr
 			}
 		default:
 			return nil, nil, IDChanges{}, err

--- a/merger/UserMarkBlockRangeMerger.go
+++ b/merger/UserMarkBlockRangeMerger.go
@@ -165,6 +165,7 @@ func mergeUMBR(left []*model.UserMarkBlockRange, right []*model.UserMarkBlockRan
 			if entry == nil {
 				continue
 			}
+			entry = model.MakeModelCopy(entry).(*model.UserMarkBlockRange)
 			// Note IDChanges if necessary
 			if entry.ID() != i {
 				if mergeSide == LeftSide {

--- a/merger/UserMarkBlockRangeMerger.go
+++ b/merger/UserMarkBlockRangeMerger.go
@@ -243,6 +243,10 @@ func detectAndFilterDuplicateBRs(idBlock []brFrom, left []*model.UserMarkBlockRa
 				}
 
 				var conflictKey strings.Builder
+				// Use UnixNano as a monotonically increasing number, so we
+				// are able to apply conflict solutions in the right order later
+				conflictKey.WriteString(fmt.Sprint(time.Now().UnixNano()))
+				conflictKey.WriteString("_")
 				conflictKey.WriteString(first.UniqueKey())
 				conflictKey.WriteString("_")
 				conflictKey.WriteString(second.UniqueKey())

--- a/merger/UserMarkBlockRangeMerger_test.go
+++ b/merger/UserMarkBlockRangeMerger_test.go
@@ -3296,8 +3296,8 @@ func Test_detectAndFilterDuplicateBRs1(t *testing.T) {
 			},
 		},
 	}
-	expectedCollisions := map[string]MergeConflict{
-		"FirstDuplicate_0_0_0_0_1_FirstDuplicate_0_0_0_0_1": {
+	expectedCollisions := []MergeConflict{
+		{
 			Left: &model.UserMarkBlockRange{
 				UserMark: &model.UserMark{
 					UserMarkID:   1,
@@ -3333,7 +3333,7 @@ func Test_detectAndFilterDuplicateBRs1(t *testing.T) {
 				},
 			},
 		},
-		"SecondDuplicate_0_0_1_2_2_SecondDuplicate_0_0_1_2_2": {
+		{
 			Left: &model.UserMarkBlockRange{
 				UserMark: &model.UserMark{
 					UserMarkID:   2,
@@ -3373,7 +3373,7 @@ func Test_detectAndFilterDuplicateBRs1(t *testing.T) {
 
 	idBlockResult, collisionsResult := detectAndFilterDuplicateBRs(idBlock, left, right)
 	assert.Equal(t, expectedIDBlocks, idBlockResult)
-	assert.Equal(t, expectedCollisions, collisionsResult)
+	assert.Equal(t, expectedCollisions, mergeConflictMapToSliceHelper(collisionsResult))
 }
 
 func Test_detectAndFilterDuplicateBRs2(t *testing.T) {
@@ -3534,8 +3534,8 @@ func Test_detectAndFilterDuplicateBRs3(t *testing.T) {
 		},
 	}
 
-	expectedCollisions := map[string]MergeConflict{
-		"Duplicate_0_0_0_0_1_Duplicate_0_0_0_0_2": {
+	expectedCollisions := []MergeConflict{
+		{
 			Left: &model.UserMarkBlockRange{
 				UserMark: &model.UserMark{
 					UserMarkID:   1,
@@ -3575,7 +3575,7 @@ func Test_detectAndFilterDuplicateBRs3(t *testing.T) {
 
 	idBlockResult, collisionsResult := detectAndFilterDuplicateBRs(idBlock, left, right)
 	assert.Equal(t, expectedIDBlocks, idBlockResult)
-	assert.Equal(t, expectedCollisions, collisionsResult)
+	assert.Equal(t, expectedCollisions, mergeConflictMapToSliceHelper(collisionsResult))
 }
 
 func Test_sortBRFroms(t *testing.T) {

--- a/merger/UserMarkBlockRangeMerger_test.go
+++ b/merger/UserMarkBlockRangeMerger_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/AndreasSko/go-jwlm/model"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -454,25 +453,22 @@ func Test_MergeUserMarkAndBlockRange_without_conflict3(t *testing.T) {
 			},
 		},
 	}
-	// expectedChanges := IDChanges{
-	// 	Left: map[int]int{},
-	// 	Right: map[int]int{
-	// 		1: 1,
-	// 		2: 2,
-	// 	},
-	// }
+	expectedChanges := IDChanges{
+		Left: map[int]int{},
+		Right: map[int]int{
+			3: 1,
+			4: 2,
+		},
+	}
 
 	leftUm, leftBr := splitUserMarkBlockRange(left)
 	rightUm, rightBr := splitUserMarkBlockRange(right)
 
-	resUm, resBr, _, err := MergeUserMarkAndBlockRange(leftUm, leftBr, rightUm, rightBr, nil)
-	spew.Dump(resUm)
-	spew.Dump(resBr)
+	resUm, resBr, changes, err := MergeUserMarkAndBlockRange(leftUm, leftBr, rightUm, rightBr, nil)
 	result := joinToUserMarkBlockRange(resUm, resBr)
-	spew.Dump(result)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedResult, result)
-	// assert.Equal(t, expectedChanges, changes)
+	assert.Equal(t, expectedChanges, changes)
 }
 
 func TestMergeUserMarkAndBlockRange_with_conflict1(t *testing.T) {

--- a/model/Database.go
+++ b/model/Database.go
@@ -435,7 +435,7 @@ func (db *Database) saveToNewSQLite(filename string) error {
 			return err
 		}
 		if err := insertEntries(sqlite, mdl); err != nil {
-			return errors.Wrapf(err, "Error while inserting %s", slice)
+			return errors.Wrapf(err, "Error while inserting entries of field %d", j)
 		}
 	}
 

--- a/model/Model.go
+++ b/model/Model.go
@@ -75,6 +75,24 @@ func MakeModelCopy(mdl Model) Model {
 		mdlCopy = &TagMap{}
 	case *UserMark:
 		mdlCopy = &UserMark{}
+	case *UserMarkBlockRange:
+		umbr := mdl.(*UserMarkBlockRange)
+
+		umCopy := &UserMark{}
+		copier.Copy(umCopy, umbr.UserMark)
+
+		// Copier doesn't deep copy slices, so doing it manually
+		brSliceCopy := make([]*BlockRange, len(umbr.BlockRanges))
+		for i, br := range umbr.BlockRanges {
+			if br != nil {
+				brSliceCopy[i] = &BlockRange{}
+				copier.Copy(brSliceCopy[i], umbr.BlockRanges[i])
+			}
+		}
+		return &UserMarkBlockRange{
+			UserMark:    umCopy,
+			BlockRanges: brSliceCopy,
+		}
 	default:
 		panic(fmt.Sprintf("Type %T is not supported for copying", mdl))
 	}

--- a/model/Model_test.go
+++ b/model/Model_test.go
@@ -19,6 +19,8 @@ func TestMakeModelCopy(t *testing.T) {
 	brCp := MakeModelCopy(br)
 	assert.Equal(t, br, brCp)
 	assert.NotSame(t, br, brCp)
+	br.SetID(5)
+	assert.Equal(t, 1, brCp.ID())
 
 	bm := &Bookmark{
 		BookmarkID:            1,
@@ -33,6 +35,8 @@ func TestMakeModelCopy(t *testing.T) {
 	bmCp := MakeModelCopy(bm)
 	assert.Equal(t, bm, bmCp)
 	assert.NotSame(t, bm, bmCp)
+	bm.SetID(5)
+	assert.Equal(t, 1, bmCp.ID())
 
 	loc := &Location{
 		LocationID:     1,
@@ -49,6 +53,8 @@ func TestMakeModelCopy(t *testing.T) {
 	locCp := MakeModelCopy(loc)
 	assert.Equal(t, loc, locCp)
 	assert.NotSame(t, loc, locCp)
+	loc.SetID(5)
+	assert.Equal(t, 1, locCp.ID())
 
 	note := &Note{
 		NoteID:          1,
@@ -64,6 +70,8 @@ func TestMakeModelCopy(t *testing.T) {
 	noteCp := MakeModelCopy(note)
 	assert.Equal(t, note, noteCp)
 	assert.NotSame(t, note, noteCp)
+	note.SetID(5)
+	assert.Equal(t, 1, noteCp.ID())
 
 	tag := &Tag{
 		TagID:         1,
@@ -74,6 +82,8 @@ func TestMakeModelCopy(t *testing.T) {
 	tagCp := MakeModelCopy(tag)
 	assert.Equal(t, tag, tagCp)
 	assert.NotSame(t, tag, tagCp)
+	tag.SetID(5)
+	assert.Equal(t, 1, tagCp.ID())
 
 	tm := &TagMap{
 		TagMapID:       1,
@@ -86,6 +96,8 @@ func TestMakeModelCopy(t *testing.T) {
 	tmCp := MakeModelCopy(tm)
 	assert.Equal(t, tm, tmCp)
 	assert.NotSame(t, tm, tmCp)
+	tm.SetID(5)
+	assert.Equal(t, 1, tmCp.ID())
 
 	um := &UserMark{
 		UserMarkID:   1,
@@ -98,11 +110,37 @@ func TestMakeModelCopy(t *testing.T) {
 	umCp := MakeModelCopy(um)
 	assert.Equal(t, um, umCp)
 	assert.NotSame(t, um, umCp)
+	um.SetID(5)
+	assert.Equal(t, 1, umCp.ID())
 
-	assert.Panics(t, func() {
-		umbr := &UserMarkBlockRange{}
-		MakeModelCopy(umbr)
-	})
+	umbr := &UserMarkBlockRange{
+		UserMark: &UserMark{
+			UserMarkID:   1,
+			ColorIndex:   1,
+			LocationID:   1,
+			StyleIndex:   1,
+			UserMarkGUID: "FIRST",
+			Version:      1,
+		},
+		BlockRanges: []*BlockRange{
+			nil,
+			{
+				BlockRangeID: 1,
+				BlockType:    1,
+				Identifier:   1,
+				StartToken:   sql.NullInt32{Int32: 1, Valid: true},
+				EndToken:     sql.NullInt32{Int32: 2, Valid: true},
+				UserMarkID:   1,
+			},
+		},
+	}
+	umbrCP := MakeModelCopy(umbr)
+	assert.Equal(t, umbr, umbrCP)
+	assert.NotSame(t, umbr, umbrCP)
+	umbr.UserMark.SetID(5)
+	umbr.BlockRanges[1].SetID(5)
+	assert.Equal(t, 1, umbrCP.(*UserMarkBlockRange).UserMark.UserMarkID)
+	assert.Equal(t, 1, umbrCP.(*UserMarkBlockRange).BlockRanges[1].BlockRangeID)
 }
 
 func TestPrettyPrint(t *testing.T) {


### PR DESCRIPTION
Fixed a few bugs that prevented successful merging. 

**🐛 Remember previous solutions when auto resolving**
When resolving merge conflicts automatically, the previous solutions would be overwritten on the next iteration. This lead to infinite loops of automatically solving the same conflicts over and over again...

**🐛 Make a copy for merged UMBRs **
The `UserMarkBlockRange` entries that went into a merged solution pointed to the same ones returned from a previous mergeConflict and so also went into possible mergeSolutions. As `mergeUMBR` updates the userMarkIDs after a successful merge, the IDs in the mergeSolutions were updated too (as they were in fact the SAME). This resulted in out-of-sync IDs when running a merge again with the previous mergeSolution. This change simply creates a copy before changing the IDs. Also added a test to detect regressions in the future.

The rest of the bugs didn't seem to have surfaced yet, but are still fixed now :)
