### PR TITLE
Mobile: More accurate DB stats

### DIFF
--- a/gomobile/Merge_test.go
+++ b/gomobile/Merge_test.go
@@ -648,7 +648,7 @@ var rightDB = &model.Database{
 	},
 }
 
-var mergedAllLeftDB = model.Database{
+var mergedAllLeftDB = &model.Database{
 	BlockRange: []*model.BlockRange{
 		nil,
 		{
@@ -821,7 +821,7 @@ var mergedAllLeftDB = model.Database{
 	},
 }
 
-var mergedAllRightDB = model.Database{
+var mergedAllRightDB = &model.Database{
 	BlockRange: []*model.BlockRange{
 		nil,
 		{

--- a/gomobile/Stats.go
+++ b/gomobile/Stats.go
@@ -1,6 +1,10 @@
 package gomobile
 
-import "github.com/AndreasSko/go-jwlm/model"
+import (
+	"reflect"
+
+	"github.com/AndreasSko/go-jwlm/model"
+)
 
 // DatabaseStats represents the rough number of entries
 // within a Database{} by defining it as the length
@@ -35,12 +39,32 @@ func (dbw *DatabaseWrapper) Stats(side string) *DatabaseStats {
 	}
 
 	return &DatabaseStats{
-		BlockRange: len(db.BlockRange),
-		Bookmark:   len(db.Bookmark),
-		Location:   len(db.Location),
-		Note:       len(db.Note),
-		Tag:        len(db.Tag),
-		TagMap:     len(db.TagMap),
-		UserMark:   len(db.UserMark),
+		BlockRange: countSliceEntries(db.BlockRange),
+		Bookmark:   countSliceEntries(db.Bookmark),
+		Location:   countSliceEntries(db.Location),
+		Note:       countSliceEntries(db.Note),
+		Tag:        countSliceEntries(db.Tag),
+		TagMap:     countSliceEntries(db.TagMap),
+		UserMark:   countSliceEntries(db.UserMark),
 	}
+}
+
+func countSliceEntries(entries interface{}) int {
+	count := 0
+
+	slice := reflect.ValueOf(entries)
+	tp := slice.Kind()
+	switch tp {
+	case reflect.Slice:
+		for j := 0; j < slice.Len(); j++ {
+			if slice.Index(j).IsNil() {
+				continue
+			}
+			count++
+		}
+	default:
+		return 0
+	}
+
+	return count
 }

--- a/gomobile/Stats_test.go
+++ b/gomobile/Stats_test.go
@@ -8,33 +8,52 @@ import (
 )
 
 func TestDatabaseWrapper_Stats(t *testing.T) {
-	db := &model.Database{
-		BlockRange: []*model.BlockRange{nil},
-		Bookmark:   []*model.Bookmark{nil, nil},
-		Location:   []*model.Location{nil, nil, nil},
-		Note:       []*model.Note{nil, nil, nil, nil},
-		Tag:        []*model.Tag{nil, nil, nil, nil, nil},
-		TagMap:     []*model.TagMap{nil, nil, nil, nil, nil, nil},
-		UserMark:   []*model.UserMark{nil, nil, nil, nil, nil, nil, nil},
-	}
 	dbw := &DatabaseWrapper{
-		left:   db,
-		right:  db,
-		merged: db,
+		left:   leftMultiCollision,
+		right:  emptyDB,
+		merged: mergedAllLeftDB,
 	}
 
-	expected := &DatabaseStats{
-		BlockRange: 1,
-		Bookmark:   2,
+	left := &DatabaseStats{
+		BlockRange: 4,
+		Bookmark:   0,
+		Location:   1,
+		Note:       0,
+		Tag:        0,
+		TagMap:     0,
+		UserMark:   4,
+	}
+	right := &DatabaseStats{
+		BlockRange: 0,
+		Bookmark:   0,
+		Location:   0,
+		Note:       0,
+		Tag:        0,
+		TagMap:     0,
+		UserMark:   0,
+	}
+	merged := &DatabaseStats{
+		BlockRange: 3,
+		Bookmark:   1,
 		Location:   3,
-		Note:       4,
-		Tag:        5,
-		TagMap:     6,
-		UserMark:   7,
+		Note:       3,
+		Tag:        4,
+		TagMap:     3,
+		UserMark:   3,
 	}
 
-	assert.Equal(t, expected, dbw.Stats("leftSide"))
-	assert.Equal(t, expected, dbw.Stats("rightSide"))
-	assert.Equal(t, expected, dbw.Stats("mergeSide"))
+	assert.Equal(t, left, dbw.Stats("leftSide"))
+	assert.Equal(t, right, dbw.Stats("rightSide"))
+	assert.Equal(t, merged, dbw.Stats("mergeSide"))
 	assert.Equal(t, &DatabaseStats{}, dbw.Stats("wrongSide"))
+}
+
+func Test_countSliceEntries(t *testing.T) {
+	assert.Equal(t, 3, countSliceEntries([]*model.BlockRange{nil, {}, {}, {}}))
+	assert.NotPanics(t, func() {
+		assert.Equal(t, 0, countSliceEntries(nil))
+		assert.Equal(t, 0, countSliceEntries([]string{}))
+		assert.Equal(t, 0, countSliceEntries(0))
+		assert.Equal(t, 0, countSliceEntries("A"))
+	})
 }


### PR DESCRIPTION
Before, DatabaseStats would just return the length for each slice of the database. As there might exist a lot of nil-values, the numbers can be quite off.
This changes it, so the actual non-nil values are counted and returned.