### PR TITLE
🐛 Consider partially migrated Bibles 

### DIFF
--- a/merger/LocationMerger.go
+++ b/merger/LocationMerger.go
@@ -10,6 +10,10 @@ import (
 // the merged locations together with a IDChanges struct indicating
 // if the ID of a location has changed.
 func MergeLocations(left []*model.Location, right []*model.Location) ([]*model.Location, IDChanges, error) {
+	// Check if one side needs to migrate the bible edition from standard to study
+	nwtstyMigrations := needsNwtstyMigration(left, right)
+	moveToNwtsty(nwtstyMigrations, left, right)
+
 	result, changes, err := tryMergeWithConflictSolver(left, right, nil, solveLocationMergeConflict)
 
 	return model.Location{}.MakeSlice(result), changes, err
@@ -38,4 +42,133 @@ func solveLocationMergeConflict(conflicts map[string]MergeConflict) (map[string]
 	}
 
 	return solution, nil
+}
+
+// bibleEditionCounts stores the number of occurences of the nwt/nwtsty bible
+// editions on the left and the right side.
+type bibleEditionCounts struct {
+	leftNwt     int
+	leftNwtsty  int
+	rightNwt    int
+	rightNwtsty int
+}
+
+// needsNwtstyMigration checks if one of the sides have been migrated from the
+// Standard Bible (nwt) to the Study Edition (nwtsty), while the other one hasn't
+// yet. If so, the side with the Standard Edition has to be migrated too, so
+// duplicate markings can still be detected later.
+//
+// Side note: JW Library did the migration by setting KeySymbols from `nwt` to
+// `nwtsty`, without changing the UserMarks themselfs, so their UserMarkGUID stayed the
+// same. If two backups with the same markings, but with one of them not
+// migrated yet, are merged, the markings can't be detected as duplicate or
+// overlapping: They techically belong to different locations, though their
+// UserMarkGUID is the same, which, when exporting, results in a unique
+// constraint violation.
+func needsNwtstyMigration(left []*model.Location, right []*model.Location) map[int]MergeSide {
+	langCounts := map[int]*bibleEditionCounts{}
+
+	for _, side := range []MergeSide{LeftSide, RightSide} {
+		var entries []*model.Location
+		if side == LeftSide {
+			entries = left
+		} else {
+			entries = right
+		}
+
+		for _, location := range entries {
+			if location == nil {
+				continue
+			}
+			if _, exists := langCounts[location.MepsLanguage]; !exists {
+				langCounts[location.MepsLanguage] = &bibleEditionCounts{0, 0, 0, 0}
+			}
+
+			nwt, nwtsty := 0, 0
+			if location.KeySymbol.String == "nwt" {
+				nwt++
+			}
+			if location.KeySymbol.String == "nwtsty" {
+				nwtsty++
+			}
+
+			if side == LeftSide {
+				langCounts[location.MepsLanguage].leftNwt += nwt
+				langCounts[location.MepsLanguage].leftNwtsty += nwtsty
+			} else {
+				langCounts[location.MepsLanguage].rightNwt += nwt
+				langCounts[location.MepsLanguage].rightNwtsty += nwtsty
+			}
+		}
+	}
+
+	return decideMigration(langCounts)
+}
+
+// decideMigration decides using bibleEditionCounts per mepsLanguage, if one side
+// needs to be migrated from nwt to nwtsty
+func decideMigration(langCounts map[int]*bibleEditionCounts) map[int]MergeSide {
+	toMigrate := map[int]MergeSide{}
+
+	for lang, counts := range langCounts {
+		leftMigrated, rightMigrated := false, false
+
+		// Consider it migrated, if the number of the study edition is way
+		// higher than the number of standard edition
+		if significantlyHigher(counts.leftNwtsty, counts.leftNwt) {
+			leftMigrated = true
+		}
+		if significantlyHigher(counts.rightNwtsty, counts.rightNwt) {
+			rightMigrated = true
+		}
+
+		// If both sides use same edition, we don't need to migrate any side
+		if leftMigrated && rightMigrated || !leftMigrated && !rightMigrated {
+			continue
+		}
+
+		if leftMigrated && !rightMigrated {
+			toMigrate[lang] = RightSide
+		} else {
+			toMigrate[lang] = LeftSide
+		}
+	}
+
+	return toMigrate
+}
+
+// moveToNwtsty moves locations from KeySymbol `nwt` to `nwtsty` if they are
+// mentioned in langs by their MepsLanguage and MergeSide.
+// This may be needed if both backups were started in the
+// normal edition, but only one side later migrated to the study edition.
+func moveToNwtsty(langs map[int]MergeSide, left []*model.Location, right []*model.Location) {
+	for _, side := range []MergeSide{LeftSide, RightSide} {
+		var locations []*model.Location
+		if side == LeftSide {
+			locations = left
+		} else {
+			locations = right
+		}
+
+		for _, location := range locations {
+			if location == nil {
+				continue
+			}
+			if _, exists := langs[location.MepsLanguage]; !exists {
+				continue
+			}
+			if side != langs[location.MepsLanguage] {
+				continue
+			}
+
+			if location.KeySymbol.String == "nwt" {
+				location.KeySymbol.String = "nwtsty"
+			}
+		}
+	}
+}
+
+// significantlyHigher checks if a is significantly (10x) higher than b
+func significantlyHigher(a, b int) bool {
+	return (float32(a) * 0.1) > float32(b)
 }

--- a/merger/LocationMerger_test.go
+++ b/merger/LocationMerger_test.go
@@ -309,6 +309,288 @@ func Test_MergeLocations(t *testing.T) {
 	assert.Equal(t, 7, right[7].LocationID)
 }
 
+func Test_MergeLocationsDiffBibleEditions(t *testing.T) {
+	left := []*model.Location{
+		nil,
+		{
+			LocationID:     1,
+			BookNumber:     sql.NullInt32{Int32: 1, Valid: true},
+			ChapterNumber:  sql.NullInt32{Int32: 1, Valid: true},
+			DocumentID:     sql.NullInt32{},
+			Track:          sql.NullInt32{},
+			IssueTagNumber: 0,
+			KeySymbol:      sql.NullString{String: "nwtsty", Valid: true},
+			MepsLanguage:   2,
+			LocationType:   0,
+			Title:          sql.NullString{String: "", Valid: true},
+		},
+		{
+			LocationID:     2,
+			BookNumber:     sql.NullInt32{Int32: 2, Valid: true},
+			ChapterNumber:  sql.NullInt32{Int32: 4, Valid: true},
+			DocumentID:     sql.NullInt32{},
+			Track:          sql.NullInt32{},
+			IssueTagNumber: 0,
+			KeySymbol:      sql.NullString{String: "nwtsty", Valid: true},
+			MepsLanguage:   2,
+			LocationType:   0,
+			Title:          sql.NullString{String: "ThisTitleShouldStay", Valid: true},
+		},
+		{
+			LocationID:     3,
+			BookNumber:     sql.NullInt32{Int32: 5, Valid: true},
+			ChapterNumber:  sql.NullInt32{Int32: 8, Valid: true},
+			DocumentID:     sql.NullInt32{},
+			Track:          sql.NullInt32{},
+			IssueTagNumber: 0,
+			KeySymbol:      sql.NullString{String: "nwtsty", Valid: true},
+			MepsLanguage:   2,
+			LocationType:   0,
+			Title:          sql.NullString{String: "", Valid: true},
+		},
+		{
+			LocationID:     4,
+			BookNumber:     sql.NullInt32{Int32: 10, Valid: true},
+			ChapterNumber:  sql.NullInt32{Int32: 8, Valid: true},
+			DocumentID:     sql.NullInt32{},
+			Track:          sql.NullInt32{},
+			IssueTagNumber: 0,
+			KeySymbol:      sql.NullString{String: "nwtsty", Valid: true},
+			MepsLanguage:   2,
+			LocationType:   0,
+			Title:          sql.NullString{String: "SomeTitle", Valid: true},
+		},
+		{
+			LocationID:     5,
+			BookNumber:     sql.NullInt32{},
+			ChapterNumber:  sql.NullInt32{},
+			DocumentID:     sql.NullInt32{Int32: 2020401, Valid: true},
+			Track:          sql.NullInt32{},
+			IssueTagNumber: 0,
+			KeySymbol:      sql.NullString{String: "w", Valid: true},
+			MepsLanguage:   2,
+			LocationType:   0,
+			Title:          sql.NullString{String: "AWTTitle", Valid: true},
+		},
+		{
+			LocationID:     6,
+			BookNumber:     sql.NullInt32{},
+			ChapterNumber:  sql.NullInt32{},
+			DocumentID:     sql.NullInt32{Int32: 2020501, Valid: true},
+			Track:          sql.NullInt32{},
+			IssueTagNumber: 0,
+			KeySymbol:      sql.NullString{String: "w", Valid: true},
+			MepsLanguage:   2,
+			LocationType:   0,
+			Title:          sql.NullString{String: "SomethingDuplicate", Valid: true},
+		},
+	}
+
+	right := []*model.Location{
+		nil,
+		{
+			LocationID:     1,
+			BookNumber:     sql.NullInt32{Int32: 1, Valid: true},
+			ChapterNumber:  sql.NullInt32{Int32: 1, Valid: true},
+			DocumentID:     sql.NullInt32{},
+			Track:          sql.NullInt32{},
+			IssueTagNumber: 0,
+			KeySymbol:      sql.NullString{String: "nwt", Valid: true},
+			MepsLanguage:   2,
+			LocationType:   0,
+			Title:          sql.NullString{String: "", Valid: true},
+		},
+		{
+			LocationID:     2,
+			BookNumber:     sql.NullInt32{Int32: 2, Valid: true},
+			ChapterNumber:  sql.NullInt32{Int32: 4, Valid: true},
+			DocumentID:     sql.NullInt32{},
+			Track:          sql.NullInt32{},
+			IssueTagNumber: 0,
+			KeySymbol:      sql.NullString{String: "nwt", Valid: true},
+			MepsLanguage:   2,
+			LocationType:   0,
+			Title:          sql.NullString{String: "ThisTitleShouldStay", Valid: true},
+		},
+		{
+			LocationID:     3,
+			BookNumber:     sql.NullInt32{Int32: 5, Valid: true},
+			ChapterNumber:  sql.NullInt32{Int32: 8, Valid: true},
+			DocumentID:     sql.NullInt32{},
+			Track:          sql.NullInt32{},
+			IssueTagNumber: 0,
+			KeySymbol:      sql.NullString{String: "nwt", Valid: true},
+			MepsLanguage:   2,
+			LocationType:   0,
+			Title:          sql.NullString{String: "ThisTitleShouldStay", Valid: true},
+		},
+		{
+			LocationID:     4,
+			BookNumber:     sql.NullInt32{Int32: 6, Valid: true},
+			ChapterNumber:  sql.NullInt32{Int32: 5, Valid: true},
+			DocumentID:     sql.NullInt32{},
+			Track:          sql.NullInt32{},
+			IssueTagNumber: 0,
+			KeySymbol:      sql.NullString{String: "nwt", Valid: true},
+			MepsLanguage:   2,
+			LocationType:   0,
+			Title:          sql.NullString{String: "SomeOtherTitle", Valid: true},
+		},
+		{
+			LocationID:     5,
+			BookNumber:     sql.NullInt32{},
+			ChapterNumber:  sql.NullInt32{},
+			DocumentID:     sql.NullInt32{Int32: 123456789, Valid: true},
+			Track:          sql.NullInt32{},
+			IssueTagNumber: 0,
+			KeySymbol:      sql.NullString{String: "CO-pgm20", Valid: true},
+			MepsLanguage:   2,
+			LocationType:   0,
+			Title:          sql.NullString{String: "ATitle", Valid: true},
+		},
+		{
+			LocationID:     6,
+			BookNumber:     sql.NullInt32{},
+			ChapterNumber:  sql.NullInt32{},
+			DocumentID:     sql.NullInt32{Int32: 123456790, Valid: true},
+			Track:          sql.NullInt32{},
+			IssueTagNumber: 0,
+			KeySymbol:      sql.NullString{String: "CO-pgm20", Valid: true},
+			MepsLanguage:   2,
+			LocationType:   0,
+			Title:          sql.NullString{String: "AATitle", Valid: true},
+		},
+		{
+			LocationID:     7,
+			BookNumber:     sql.NullInt32{},
+			ChapterNumber:  sql.NullInt32{},
+			DocumentID:     sql.NullInt32{Int32: 2020501, Valid: true},
+			Track:          sql.NullInt32{},
+			IssueTagNumber: 0,
+			KeySymbol:      sql.NullString{String: "w", Valid: true},
+			MepsLanguage:   2,
+			LocationType:   0,
+			Title:          sql.NullString{String: "SomethingDuplicate", Valid: true},
+		},
+	}
+
+	expectedResult := []*model.Location{
+		nil,
+		{
+			LocationID:     1,
+			BookNumber:     sql.NullInt32{Int32: 1, Valid: true},
+			ChapterNumber:  sql.NullInt32{Int32: 1, Valid: true},
+			DocumentID:     sql.NullInt32{},
+			Track:          sql.NullInt32{},
+			IssueTagNumber: 0,
+			KeySymbol:      sql.NullString{String: "nwtsty", Valid: true},
+			MepsLanguage:   2,
+			LocationType:   0,
+			Title:          sql.NullString{String: "", Valid: true},
+		},
+		{
+			LocationID:     2,
+			BookNumber:     sql.NullInt32{Int32: 2, Valid: true},
+			ChapterNumber:  sql.NullInt32{Int32: 4, Valid: true},
+			DocumentID:     sql.NullInt32{},
+			Track:          sql.NullInt32{},
+			IssueTagNumber: 0,
+			KeySymbol:      sql.NullString{String: "nwtsty", Valid: true},
+			MepsLanguage:   2,
+			LocationType:   0,
+			Title:          sql.NullString{String: "ThisTitleShouldStay", Valid: true},
+		},
+		{
+			LocationID:     3,
+			BookNumber:     sql.NullInt32{Int32: 5, Valid: true},
+			ChapterNumber:  sql.NullInt32{Int32: 8, Valid: true},
+			DocumentID:     sql.NullInt32{},
+			Track:          sql.NullInt32{},
+			IssueTagNumber: 0,
+			KeySymbol:      sql.NullString{String: "nwtsty", Valid: true},
+			MepsLanguage:   2,
+			LocationType:   0,
+			Title:          sql.NullString{String: "ThisTitleShouldStay", Valid: true},
+		},
+		{
+			LocationID:     4,
+			BookNumber:     sql.NullInt32{Int32: 10, Valid: true},
+			ChapterNumber:  sql.NullInt32{Int32: 8, Valid: true},
+			DocumentID:     sql.NullInt32{},
+			Track:          sql.NullInt32{},
+			IssueTagNumber: 0,
+			KeySymbol:      sql.NullString{String: "nwtsty", Valid: true},
+			MepsLanguage:   2,
+			LocationType:   0,
+			Title:          sql.NullString{String: "SomeTitle", Valid: true},
+		},
+		{
+			LocationID:     5,
+			BookNumber:     sql.NullInt32{Int32: 6, Valid: true},
+			ChapterNumber:  sql.NullInt32{Int32: 5, Valid: true},
+			DocumentID:     sql.NullInt32{},
+			Track:          sql.NullInt32{},
+			IssueTagNumber: 0,
+			KeySymbol:      sql.NullString{String: "nwtsty", Valid: true},
+			MepsLanguage:   2,
+			LocationType:   0,
+			Title:          sql.NullString{String: "SomeOtherTitle", Valid: true},
+		},
+		{
+			LocationID:     6,
+			BookNumber:     sql.NullInt32{},
+			ChapterNumber:  sql.NullInt32{},
+			DocumentID:     sql.NullInt32{Int32: 2020401, Valid: true},
+			Track:          sql.NullInt32{},
+			IssueTagNumber: 0,
+			KeySymbol:      sql.NullString{String: "w", Valid: true},
+			MepsLanguage:   2,
+			LocationType:   0,
+			Title:          sql.NullString{String: "AWTTitle", Valid: true},
+		},
+		{
+			LocationID:     7,
+			BookNumber:     sql.NullInt32{},
+			ChapterNumber:  sql.NullInt32{},
+			DocumentID:     sql.NullInt32{Int32: 123456789, Valid: true},
+			Track:          sql.NullInt32{},
+			IssueTagNumber: 0,
+			KeySymbol:      sql.NullString{String: "CO-pgm20", Valid: true},
+			MepsLanguage:   2,
+			LocationType:   0,
+			Title:          sql.NullString{String: "ATitle", Valid: true},
+		},
+		{
+			LocationID:     8,
+			BookNumber:     sql.NullInt32{},
+			ChapterNumber:  sql.NullInt32{},
+			DocumentID:     sql.NullInt32{Int32: 2020501, Valid: true},
+			Track:          sql.NullInt32{},
+			IssueTagNumber: 0,
+			KeySymbol:      sql.NullString{String: "w", Valid: true},
+			MepsLanguage:   2,
+			LocationType:   0,
+			Title:          sql.NullString{String: "SomethingDuplicate", Valid: true},
+		},
+		{
+			LocationID:     9,
+			BookNumber:     sql.NullInt32{},
+			ChapterNumber:  sql.NullInt32{},
+			DocumentID:     sql.NullInt32{Int32: 123456790, Valid: true},
+			Track:          sql.NullInt32{},
+			IssueTagNumber: 0,
+			KeySymbol:      sql.NullString{String: "CO-pgm20", Valid: true},
+			MepsLanguage:   2,
+			LocationType:   0,
+			Title:          sql.NullString{String: "AATitle", Valid: true},
+		},
+	}
+
+	result, _, _ := MergeLocations(left, right)
+
+	assert.Equal(t, expectedResult, result)
+}
+
 func Benchmark_MergeLocations(b *testing.B) {
 	const locationCount = 1000000
 	left := make([]*model.Location, locationCount+1)
@@ -524,4 +806,243 @@ func Test_solveLocationMergeConflict(t *testing.T) {
 		}
 		solveLocationMergeConflict(panicConflict)
 	})
+}
+
+func Test_needsNwtstyMigration(t *testing.T) {
+	type args struct {
+		left  []*model.Location
+		right []*model.Location
+	}
+	tests := []struct {
+		args args
+		want map[int]MergeSide
+	}{
+		{
+			args: args{
+				left: []*model.Location{
+					{KeySymbol: sql.NullString{"nwtsty", true}, MepsLanguage: 1},
+					{KeySymbol: sql.NullString{"nwtsty", true}, MepsLanguage: 1},
+					{KeySymbol: sql.NullString{"nwtsty", true}, MepsLanguage: 1},
+					{KeySymbol: sql.NullString{"other", true}, MepsLanguage: 1},
+					{KeySymbol: sql.NullString{"nwtsty", true}, MepsLanguage: 1},
+					{KeySymbol: sql.NullString{"nwtsty", true}, MepsLanguage: 1},
+					{KeySymbol: sql.NullString{"nwtsty", true}, MepsLanguage: 1},
+					{KeySymbol: sql.NullString{"nwtsty", true}, MepsLanguage: 1},
+					{KeySymbol: sql.NullString{"nwtsty", true}, MepsLanguage: 1},
+					{KeySymbol: sql.NullString{"nwtsty", true}, MepsLanguage: 1},
+					{KeySymbol: sql.NullString{"nwtsty", true}, MepsLanguage: 1},
+					{KeySymbol: sql.NullString{"otherother", true}, MepsLanguage: 1},
+					{KeySymbol: sql.NullString{"nwtsty", true}, MepsLanguage: 1},
+					{KeySymbol: sql.NullString{"nwt", true}, MepsLanguage: 1},
+				},
+				right: []*model.Location{
+					{KeySymbol: sql.NullString{"nwtsty", true}, MepsLanguage: 1},
+					{KeySymbol: sql.NullString{"other", true}, MepsLanguage: 1},
+					{KeySymbol: sql.NullString{"nwtsty", true}, MepsLanguage: 1},
+					{KeySymbol: sql.NullString{"nwtsty", true}, MepsLanguage: 1},
+					{KeySymbol: sql.NullString{"nwtsty", true}, MepsLanguage: 1},
+				},
+			},
+			want: map[int]MergeSide{},
+		},
+		{
+			args: args{
+				left: []*model.Location{
+					{KeySymbol: sql.NullString{"nwtsty", true}, MepsLanguage: 0},
+					{KeySymbol: sql.NullString{"nwtsty", true}, MepsLanguage: 0},
+					{KeySymbol: sql.NullString{"nwtsty", true}, MepsLanguage: 0},
+					{KeySymbol: sql.NullString{"nwtsty", true}, MepsLanguage: 1},
+				},
+				right: []*model.Location{
+					{KeySymbol: sql.NullString{"nwt", true}, MepsLanguage: 0},
+					{KeySymbol: sql.NullString{"nwt", true}, MepsLanguage: 0},
+					{KeySymbol: sql.NullString{"nwt", true}, MepsLanguage: 0},
+					{KeySymbol: sql.NullString{"nwtsty", true}, MepsLanguage: 1},
+					{KeySymbol: sql.NullString{"nwtsty", true}, MepsLanguage: 1},
+					{KeySymbol: sql.NullString{"nwtsty", true}, MepsLanguage: 1},
+				},
+			},
+			want: map[int]MergeSide{
+				0: RightSide,
+			},
+		},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, needsNwtstyMigration(tt.args.left, tt.args.right), tt.args)
+	}
+}
+
+func Test_decideMigration(t *testing.T) {
+	type args struct {
+		langCounts map[int]*bibleEditionCounts
+	}
+	tests := []struct {
+		args args
+		want map[int]MergeSide
+	}{
+		{
+			args: args{
+				langCounts: map[int]*bibleEditionCounts{
+					1: {
+						leftNwt:     287,
+						leftNwtsty:  2,
+						rightNwt:    2,
+						rightNwtsty: 34,
+					},
+				},
+			},
+			want: map[int]MergeSide{
+				1: LeftSide,
+			},
+		},
+		{
+			args: args{
+				langCounts: map[int]*bibleEditionCounts{
+					0: {
+						leftNwt:     1,
+						leftNwtsty:  36,
+						rightNwt:    0,
+						rightNwtsty: 152,
+					},
+					1: {
+						leftNwt:     1,
+						leftNwtsty:  541,
+						rightNwt:    2,
+						rightNwtsty: 125,
+					},
+				},
+			},
+			want: map[int]MergeSide{},
+		},
+		{
+			args: args{
+				langCounts: map[int]*bibleEditionCounts{
+					0: {
+						leftNwt:     36,
+						leftNwtsty:  1,
+						rightNwt:    152,
+						rightNwtsty: 0,
+					},
+					1: {
+						leftNwt:     541,
+						leftNwtsty:  1,
+						rightNwt:    125,
+						rightNwtsty: 2,
+					},
+				},
+			},
+			want: map[int]MergeSide{},
+		},
+		{
+			args: args{
+				langCounts: map[int]*bibleEditionCounts{
+					0: {
+						leftNwt:     1,
+						leftNwtsty:  36,
+						rightNwt:    152,
+						rightNwtsty: 0,
+					},
+					1: {
+						leftNwt:     541,
+						leftNwtsty:  1,
+						rightNwt:    125,
+						rightNwtsty: 2,
+					},
+				},
+			},
+			want: map[int]MergeSide{
+				0: RightSide,
+			},
+		},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, decideMigration(tt.args.langCounts), tt.args)
+	}
+}
+
+func Test_moveToNwtsty(t *testing.T) {
+	type args struct {
+		langs map[int]MergeSide
+		left  []*model.Location
+		right []*model.Location
+	}
+	tests := []struct {
+		args args
+		want args
+	}{
+		{
+			args: args{
+				langs: map[int]MergeSide{
+					0: LeftSide,
+					1: RightSide,
+				},
+				left: []*model.Location{
+					{KeySymbol: sql.NullString{"nwt", true}, MepsLanguage: 1},
+					{KeySymbol: sql.NullString{"other", true}, MepsLanguage: 1},
+					{KeySymbol: sql.NullString{"other", true}, MepsLanguage: 0},
+					{KeySymbol: sql.NullString{"nwtsty", true}, MepsLanguage: 0},
+					{KeySymbol: sql.NullString{"nwt", true}, MepsLanguage: 0},
+				},
+				right: []*model.Location{
+					{KeySymbol: sql.NullString{"nwt", true}, MepsLanguage: 0},
+					{KeySymbol: sql.NullString{"nwt", true}, MepsLanguage: 1},
+					{KeySymbol: sql.NullString{"nwtsty", true}, MepsLanguage: 0},
+				},
+			},
+			want: args{
+				left: []*model.Location{
+					{KeySymbol: sql.NullString{"nwt", true}, MepsLanguage: 1},
+					{KeySymbol: sql.NullString{"other", true}, MepsLanguage: 1},
+					{KeySymbol: sql.NullString{"other", true}, MepsLanguage: 0},
+					{KeySymbol: sql.NullString{"nwtsty", true}, MepsLanguage: 0},
+					{KeySymbol: sql.NullString{"nwtsty", true}, MepsLanguage: 0},
+				},
+				right: []*model.Location{
+					{KeySymbol: sql.NullString{"nwt", true}, MepsLanguage: 0},
+					{KeySymbol: sql.NullString{"nwtsty", true}, MepsLanguage: 1},
+					{KeySymbol: sql.NullString{"nwtsty", true}, MepsLanguage: 0},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		moveToNwtsty(tt.args.langs, tt.args.left, tt.args.right)
+		assert.Equal(t, tt.want.left, tt.args.left, tt.args.left)
+		assert.Equal(t, tt.want.right, tt.args.right, tt.args.right)
+	}
+}
+
+func Test_significantlyHigher(t *testing.T) {
+	type args struct {
+		a int
+		b int
+	}
+	tests := []struct {
+		args args
+		want bool
+	}{
+		{
+			args: args{a: 1, b: 2},
+			want: false,
+		},
+		{
+			args: args{a: 10, b: 2},
+			want: false,
+		},
+		{
+			args: args{a: 25, b: 2},
+			want: true,
+		},
+		{
+			args: args{a: 11, b: 1},
+			want: true,
+		},
+		{
+			args: args{a: 1, b: 20},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, significantlyHigher(tt.args.a, tt.args.b), tt.args)
+	}
 }

--- a/merger/TagMapMerger.go
+++ b/merger/TagMapMerger.go
@@ -38,7 +38,7 @@ func MergeTagMaps(left []*model.TagMap, right []*model.TagMap, conflictSolution 
 	// Go through map in sorted order so we have deterministic results
 	sortedTagIDs := make([]int, len(tags))
 	i := 0
-	for key, _ := range tags {
+	for key := range tags {
 		sortedTagIDs[i] = key
 		i++
 	}


### PR DESCRIPTION
When the Study Edition of the Revised New World Translation was published, JW Library offered to migrate all previous markings from the Standard Edition to the Study Edition. It did that by simply replacing the KeySymbols in Locations from `nwt` to `nwtsty`, while keeping the UserMarkGUIDs etc. the same.
When merging two backups with the same markings, while one side has already been migrated to `nwtsty`, markings can't be detected as duplicate or overlapping anymore: They techically belong to different locations, while their UserMarkGUID stays the same. This results in UserMarks with the same GUID, but different locations (one for `nwt` and one for `nwtsty`), which, when exporting, leads to a unique constraint violation.

This commits adds a check that checks if one side has migrated to the Study Edition, while the other one has not. In this case, it will also migrate the other side to `nwtsty`.