### PR TITLE
CI: Test Gomobile (iOS) build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,6 @@ name: CI
 on: [push]
 jobs:
   golangci-lint:
-    name: golangci-lint
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
@@ -26,3 +25,21 @@ jobs:
         uses: actions/checkout@v2
       - name: Run tests
         run: go test ./...
+    
+  gomobile-ios:
+    runs-on: macos-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.14'
+      - name: Install Gomobile
+        run: go get golang.org/x/mobile/cmd/gomobile
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Initialize Gomobile
+        run: gomobile init
+        working-directory: gomobile
+      - name: Build for iOS
+        run: gomobile bind -target ios -v
+        working-directory: gomobile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go


### PR DESCRIPTION
Updating dependencies sometimes break the building process of Gomobile. To find these issues early on, it's good to run a build-test in CI. 
This adds a `gomobile-ios` job that runs `gomobile bind -target ios` on every CI run so we are more confident that a change does not break the iOS app. 

## Other changes:
If the test in one environment/OS fails it won't cancel the other tests.