### PR TITLE
:zap: Don't compile Regex multiple times

### DIFF
--- a/merger/UserMarkBlockRangeMerger.go
+++ b/merger/UserMarkBlockRangeMerger.go
@@ -335,6 +335,8 @@ func replaceUMBRConflictsWithSolution(left *[]*model.UserMarkBlockRange, right *
 	return changes, invertedChanges
 }
 
+var extractKeyNumber = regexp.MustCompile(`^(\d*)`)
+
 // sortedSolutionKeys returns a list of keys from the conflictSolution map,
 // where the keys are sorted by the first number-part of a key (i.e.
 // 12345_uniqueKey would be sorted according to 12345).
@@ -347,10 +349,9 @@ func sortedSolutionKeys(conflictSolution map[string]MergeSolution) []string {
 	// Extract first part of key, which is a monotonically increasing number,
 	// afterwards sort it. Ignore errors and in these cases just set the number
 	// to 0.
-	re := regexp.MustCompile(`^(\d*)`)
 	i := 0
 	for key := range conflictSolution {
-		match := re.FindStringSubmatch(key)
+		match := extractKeyNumber.FindStringSubmatch(key)
 		number, _ := strconv.ParseInt(match[0], 0, 64)
 		orderedKeys[i] = struct {
 			number int64

--- a/model/UserMarkBlockRange.go
+++ b/model/UserMarkBlockRange.go
@@ -42,22 +42,22 @@ func (m *UserMarkBlockRange) UniqueKey() string {
 	return sb.String()
 }
 
+var rmUID = regexp.MustCompile(`^(\d*_\d*_\d*_\d*)(_\d*)`)
+
 // Equals checks if the UserMarkBlockRange is equal to the given one.
 // It will both check its UserMark and all BlockRanges.
 func (m *UserMarkBlockRange) Equals(m2 Model) bool {
 	// Remove UserMarkID from UniqueKey, as BlockRanges have already
-	// been joined with UserMark
-	re := regexp.MustCompile(`^(\d*_\d*_\d*_\d*)(_\d*)`)
-
+	// been joined with UserMark.
 	// Compare UniqueKeys of both BlockRanges to check if they are the same
 	mBRKeys := make(map[string]bool, len(m.BlockRanges))
 	m2BRKeys := make(map[string]bool, len(m2.(*UserMarkBlockRange).BlockRanges))
 	for _, br := range m.BlockRanges {
-		uq := re.ReplaceAllString(br.UniqueKey(), "$1")
+		uq := rmUID.ReplaceAllString(br.UniqueKey(), "$1")
 		mBRKeys[uq] = true
 	}
 	for _, br := range m2.(*UserMarkBlockRange).BlockRanges {
-		uq := re.ReplaceAllString(br.UniqueKey(), "$1")
+		uq := rmUID.ReplaceAllString(br.UniqueKey(), "$1")
 		m2BRKeys[uq] = true
 	}
 


### PR DESCRIPTION
Especially for comparing UMBRs, the Regex was compiled thousands of times, resulting in 120ms of `regexp.MustCompile` when merging my personal backup (25k markings).

By taking this out of the function, it only needs to run once.