### PR TITLE
⚡ Two small performance improvements

### DIFF
--- a/merger/UserMarkBlockRangeMerger.go
+++ b/merger/UserMarkBlockRangeMerger.go
@@ -123,6 +123,7 @@ func mergeUMBR(left []*model.UserMarkBlockRange, right []*model.UserMarkBlockRan
 						second = right[br.br.UserMarkID]
 					}
 					var conflictKey strings.Builder
+					conflictKey.Grow(160)
 					// Use UnixNano as a monotonically increasing number, so we
 					// are able to apply conflict solutions in the right order later
 					conflictKey.WriteString(fmt.Sprint(time.Now().UnixNano()))

--- a/model/UserMarkBlockRange.go
+++ b/model/UserMarkBlockRange.go
@@ -54,11 +54,11 @@ func (m *UserMarkBlockRange) Equals(m2 Model) bool {
 	mBRKeys := make(map[string]bool, len(m.BlockRanges))
 	m2BRKeys := make(map[string]bool, len(m2.(*UserMarkBlockRange).BlockRanges))
 	for _, br := range m.BlockRanges {
-		uq := rmUID.ReplaceAllString(br.UniqueKey(), "$1")
+		uq := rmUID.FindStringSubmatch(br.UniqueKey())[1]
 		mBRKeys[uq] = true
 	}
 	for _, br := range m2.(*UserMarkBlockRange).BlockRanges {
-		uq := rmUID.ReplaceAllString(br.UniqueKey(), "$1")
+		uq := rmUID.FindStringSubmatch(br.UniqueKey())[1]
 		m2BRKeys[uq] = true
 	}
 

--- a/model/UserMarkBlockRange.go
+++ b/model/UserMarkBlockRange.go
@@ -30,6 +30,7 @@ func (m *UserMarkBlockRange) SetID(id int) {
 // so it can be used as a key in a map.
 func (m *UserMarkBlockRange) UniqueKey() string {
 	var sb strings.Builder
+	sb.Grow(70)
 	sb.WriteString(m.UserMark.UniqueKey())
 	sb.WriteString("_")
 	for i, br := range m.BlockRanges {


### PR DESCRIPTION
### ⚡ Grow strings.Builder at beginning 
This should reduce the number of `growSlice` operations resulting in some minor speedups. The number was determined by looking at the average size of keys.

### ⚡ More efficient Regex umbr.Equals 
Instead of doing replace, a `FindStringSubmatch` is actually all that's needed. It is just a minor change, but still reduces the runtime by a few tens of milliseconds.

See #47 for a similar improvement.