### PR TITLE
✨ `purge` command to remove data from specific tables

### DIFF
--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -232,7 +232,9 @@ func merge(leftFilename string, rightFilename string, mergedFilename string, std
 	fmt.Fprintln(stdio.Out, "🎉 Finished merging!")
 
 	fmt.Fprintln(stdio.Out, "⌛ Preparing merged database for exporting")
-	merger.PrepareDatabasesPostMerge(&merged)
+	if err := merger.PrepareDatabasesPostMerge(&merged); err != nil {
+		log.Fatal(err)
+	}
 
 	fmt.Fprintln(stdio.Out, "Exporting merged database")
 	if err = merged.ExportJWLBackup(mergedFilename); err != nil {

--- a/cmd/purge.go
+++ b/cmd/purge.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/AlecAivazis/survey/v2/terminal"
+	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/MakeNowJust/heredoc"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var purgeCmd = &cobra.Command{
+	Use:   "purge <input-backup> <output-backup>",
+	Short: "Remove all entries of specific tables",
+	Long: heredoc.Doc(`Remove all entries of the given tables from the input backup and store it as output. 
+	This can be useful in case you want to share the backup with someone else, but want to remove some data.
+	
+	Valid table names are: 
+	 * BlockRange
+	 * Bookmark
+	 * InputField
+	 * Location
+	 * Note
+	 * Tag
+	 * TagMap
+	 * UserMark`),
+	Example: `go-jwlm purge original.jwlibrary purged.jwlibrary --tables=Note,Tag,TagMap`,
+	Run: func(cmd *cobra.Command, args []string) {
+		inputFilename := args[0]
+		outputFilename := args[1]
+		purge(inputFilename, outputFilename, terminal.Stdio{In: os.Stdin, Out: os.Stdout, Err: os.Stderr})
+	},
+	Args: cobra.ExactArgs(2),
+}
+
+var Tables string
+
+func purge(inputFilename string, outputFilename string, stdio terminal.Stdio) {
+	fmt.Fprintln(stdio.Out, "Importing backup")
+	db := &model.Database{}
+	err := db.ImportJWLBackup(inputFilename)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	Tables = strings.ReplaceAll(Tables, " ", "")
+	tableSlice := strings.Split(Tables, ",")
+
+	fmt.Fprintln(stdio.Out, "🔥 Purging the following tables:", strings.TrimSuffix(strings.Join(tableSlice, ", "), ","))
+	err = db.PurgeTables(tableSlice)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Fprintln(stdio.Out, "💾 Storing backup")
+	if err = db.ExportJWLBackup(outputFilename); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Fprintln(stdio.Out, "🎉 Done")
+}
+
+func init() {
+	rootCmd.AddCommand(purgeCmd)
+	purgeCmd.Flags().StringVar(&Tables, "tables", "", "Comma-separated list of tables that should be purged from the backup")
+}

--- a/cmd/purge_test.go
+++ b/cmd/purge_test.go
@@ -1,4 +1,5 @@
 //go:build !windows
+// +build !windows
 
 package cmd
 

--- a/cmd/purge_test.go
+++ b/cmd/purge_test.go
@@ -1,0 +1,49 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/AlecAivazis/survey/v2/terminal"
+	"github.com/AndreasSko/go-jwlm/model"
+	expect "github.com/Netflix/go-expect"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_purge(t *testing.T) {
+	t.Parallel()
+
+	tmp, err := ioutil.TempDir("", "go-jwlm")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmp)
+
+	inputFilename := filepath.Join(tmp, "left.jwlibrary")
+	assert.NoError(t, leftDB.ExportJWLBackup(inputFilename))
+
+	RunCmdTest(t,
+		func(t *testing.T, c *expect.Console) {
+			_, err := c.ExpectString("🎉 Done")
+			assert.NoError(t, err)
+			_, err = c.ExpectEOF()
+			assert.NoError(t, err)
+		},
+		func(t *testing.T, c *expect.Console) {
+			Tables = "Note,Tag,TagMap"
+
+			outputFilename := filepath.Join(tmp, "1.jwlibrary")
+			purge(inputFilename, outputFilename, terminal.Stdio{In: c.Tty(), Out: c.Tty(), Err: c.Tty()})
+
+			want := model.MakeDatabaseCopy(leftDB)
+			want.Note = []*model.Note{nil}
+			want.Tag = []*model.Tag{nil}
+			want.TagMap = []*model.TagMap{nil}
+
+			output := &model.Database{}
+			assert.NoError(t, output.ImportJWLBackup(outputFilename))
+			assert.True(t, want.Equals(output))
+		})
+}

--- a/model/Database.go
+++ b/model/Database.go
@@ -59,6 +59,29 @@ func (db *Database) FetchFromTable(tableName string, id int) Model {
 	return table.Index(id).Interface().(Model)
 }
 
+// PurgeTables removes all entries from the tables mentioned in the tables slice,
+// which are named by the fields of the Database slice. If a table doesn't exist,
+// an error will be returned.
+func (db *Database) PurgeTables(tables []string) error {
+	if db == nil {
+		return fmt.Errorf("can't purge tables. Database is nil")
+	}
+
+	for _, tableName := range tables {
+		if tableName == "" {
+			continue
+		}
+
+		table := reflect.ValueOf(db).Elem().FieldByName(tableName)
+		if !table.IsValid() {
+			return fmt.Errorf("table %s does not exist in database", tableName)
+		}
+		table.Set(reflect.MakeSlice(table.Type(), 1, 1))
+	}
+
+	return nil
+}
+
 // MakeDatabaseCopy creates a deep copy of the given Database, so elements of
 // the copy can be safely updated without affecting the original one.
 func MakeDatabaseCopy(db *Database) *Database {


### PR DESCRIPTION
This adds a new command called `purge` that allows purging specific tables of a backup. The command can be useful when sharing a backup with someone else, while wanting to keep some data private.

Example: If I would like to remove all of my notes, tags, and tagMaps I can simply run:

```shell
go-jwlm purge backup.jwlibrary purged.jwlibrary --tables=Note,Tag,TagMap
```

## Other changes:
* 🐛 Fail in case post-merge prepare db fails