### PR TITLE
:bug: Skip UserMarks with no BlockRange attached

### DIFF
--- a/cmd/merge_test.go
+++ b/cmd/merge_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package cmd
@@ -188,6 +189,42 @@ func Test_merge(t *testing.T) {
 			merged := &model.Database{}
 			merged.ImportJWLBackup(mergedFilename)
 			assert.True(t, mergedDBNwtWithDifferentDocID.Equals(merged))
+		})
+
+	// Merge with marking containing no BlockRanges and selecting all left
+	RunCmdTest(t,
+		func(t *testing.T, c *expect.Console) {
+			c.ExpectString("📑 Merging Bookmarks")
+			c.SendLine("")
+
+			c.ExpectString("✍️  Merging InputFields")
+			c.SendLine("")
+
+			c.ExpectString("🖍  Merging Markings")
+			c.SendLine("")
+
+			c.ExpectString("📝 Merging Notes")
+			c.SendLine("")
+
+			_, err := c.ExpectString("🎉 Finished merging!")
+			assert.NoError(t, err)
+			c.ExpectEOF()
+		},
+		func(t *testing.T, c *expect.Console) {
+			leftDBEmptyBRFilename := filepath.Join(tmp, "leftDBEmptyBRFilename.jwlibrary")
+			assert.NoError(t, leftDBEmptyBR.ExportJWLBackup(leftDBEmptyBRFilename))
+			RightDBEmptyBRFilename := filepath.Join(tmp, "RightDBEmptyBRFilename.jwlibrary")
+			assert.NoError(t, RightDBEmptyBR.ExportJWLBackup(RightDBEmptyBRFilename))
+			mergedAllLeftDBEmptyBRFilename := filepath.Join(tmp, "mergedAllLeftDBEmptyBRFilename.jwlibrary")
+			assert.NoError(t, mergedAllLeftDBEmptyBR.ExportJWLBackup(mergedAllLeftDBEmptyBRFilename))
+
+			merge(leftDBEmptyBRFilename,
+				RightDBEmptyBRFilename,
+				mergedFilename,
+				terminal.Stdio{In: c.Tty(), Out: c.Tty(), Err: c.Tty()})
+			merged := &model.Database{}
+			merged.ImportJWLBackup(mergedAllLeftDBEmptyBRFilename)
+			assert.True(t, mergedAllLeftDBEmptyBR.Equals(merged))
 		})
 }
 
@@ -1580,6 +1617,538 @@ var mergedDBNwtWithDifferentDocID = &model.Database{
 			LocationID:   3,
 			StyleIndex:   0,
 			UserMarkGUID: "This should stay in nwt because of different DocumentIDs",
+			Version:      1,
+		},
+	},
+}
+
+var leftDBEmptyBR = &model.Database{
+	BlockRange: []*model.BlockRange{
+		nil,
+		{
+			BlockRangeID: 1,
+			BlockType:    2,
+			Identifier:   1,
+			StartToken:   sql.NullInt32{0, true},
+			EndToken:     sql.NullInt32{7, true},
+			UserMarkID:   1,
+		},
+	},
+	Bookmark: []*model.Bookmark{
+		nil,
+		{
+			BookmarkID:            1,
+			LocationID:            1,
+			PublicationLocationID: 2,
+			Title:                 "1. Mose 1:1",
+			Snippet:               sql.NullString{"1 Am Anfang erschuf Gott Himmel und Erde.", true},
+			BlockType:             2,
+			BlockIdentifier:       sql.NullInt32{1, true},
+		},
+	},
+	InputField: []*model.InputField{
+		nil,
+		{
+			LocationID: 5,
+			TextTag:    "a1",
+			Value:      "a1",
+		},
+		{
+			LocationID: 5,
+			TextTag:    "a2",
+			Value:      "a2",
+		},
+	},
+	Location: []*model.Location{
+		nil,
+		{
+			LocationID:    1,
+			BookNumber:    sql.NullInt32{1, true},
+			ChapterNumber: sql.NullInt32{1, true},
+			KeySymbol:     sql.NullString{"nwtsty", true},
+			MepsLanguage:  2,
+			LocationType:  0,
+			Title:         sql.NullString{"1. Mose 1", true},
+		},
+		{
+			LocationID:   2,
+			KeySymbol:    sql.NullString{"nwtsty", true},
+			MepsLanguage: 2,
+			LocationType: 1,
+		},
+		nil,
+		nil,
+		{
+			LocationID:   5,
+			DocumentID:   sql.NullInt32{1102021811, true},
+			KeySymbol:    sql.NullString{"lffi", true},
+			MepsLanguage: 2,
+			LocationType: 0,
+		},
+	},
+	Note: []*model.Note{
+		nil,
+		{
+			NoteID:          1,
+			GUID:            "92B192B4-B0B9-49B2-949F-7A8BA6406AF4",
+			UserMarkID:      sql.NullInt32{1, true},
+			LocationID:      sql.NullInt32{1, true},
+			Title:           sql.NullString{"Am Anfang erschuf Gott Himmel und Erde.", true},
+			Content:         sql.NullString{"📝 for left version", true},
+			LastModified:    "2020-09-15T13:45:38+00:00",
+			BlockType:       2,
+			BlockIdentifier: sql.NullInt32{1, true},
+		},
+		{
+			NoteID:       2,
+			GUID:         "E36B34A0-B70F-4590-9D69-5887AB65A6D5",
+			Title:        sql.NullString{"Same Note", true},
+			Content:      sql.NullString{"This note is also available on the other side", true},
+			LastModified: "2020-09-15T13:52:25+00:00",
+			BlockType:    0,
+		},
+	},
+	Tag: []*model.Tag{
+		nil,
+		{
+			TagID:   1,
+			TagType: 0,
+			Name:    "Favorite",
+		},
+		{
+			TagID:   2,
+			TagType: 1,
+			Name:    "Left",
+		},
+		{
+			TagID:   3,
+			TagType: 1,
+			Name:    "Same",
+		},
+	},
+	TagMap: []*model.TagMap{
+		nil,
+		{
+			TagMapID: 1,
+			NoteID:   sql.NullInt32{1, true},
+			TagID:    2,
+			Position: 0,
+		},
+		{
+			TagMapID: 2,
+			NoteID:   sql.NullInt32{2, true},
+			TagID:    3,
+			Position: 0,
+		},
+	},
+	UserMark: []*model.UserMark{
+		nil,
+		{
+			UserMarkID:   1,
+			ColorIndex:   1,
+			LocationID:   1,
+			StyleIndex:   0,
+			UserMarkGUID: "0D5523D9-F784-4B08-A86D-D517F4EB17DE",
+			Version:      1,
+		},
+		{
+			UserMarkID:   2,
+			ColorIndex:   1,
+			LocationID:   1,
+			StyleIndex:   0,
+			UserMarkGUID: "No BlockRanges",
+			Version:      1,
+		},
+	},
+}
+
+var RightDBEmptyBR = &model.Database{
+	BlockRange: []*model.BlockRange{
+		nil,
+		{
+			BlockRangeID: 1,
+			BlockType:    2,
+			Identifier:   1,
+			StartToken:   sql.NullInt32{0, true},
+			EndToken:     sql.NullInt32{15, true},
+			UserMarkID:   1,
+		},
+		{
+			BlockRangeID: 2,
+			BlockType:    2,
+			Identifier:   1,
+			StartToken:   sql.NullInt32{0, true},
+			EndToken:     sql.NullInt32{7, true},
+			UserMarkID:   2,
+		},
+		{
+			BlockRangeID: 3,
+			BlockType:    2,
+			Identifier:   2,
+			StartToken:   sql.NullInt32{0, true},
+			EndToken:     sql.NullInt32{12, true},
+			UserMarkID:   2,
+		},
+		{
+			BlockRangeID: 4,
+			BlockType:    2,
+			Identifier:   2,
+			StartToken:   sql.NullInt32{13, true},
+			EndToken:     sql.NullInt32{26, true},
+			UserMarkID:   3,
+		},
+	},
+	Bookmark: []*model.Bookmark{
+		nil,
+		{
+			BookmarkID:            1,
+			LocationID:            1,
+			PublicationLocationID: 2,
+			Title:                 "1. Mose 2:1",
+			Snippet:               sql.NullString{"2 So wurde die Erschaffung von Himmel und Erde und allem, was dazugehört, beendet. ", true},
+			BlockType:             2,
+			BlockIdentifier:       sql.NullInt32{1, true},
+		},
+	},
+	InputField: []*model.InputField{
+		nil,
+		{
+			LocationID: 4,
+			TextTag:    "a1",
+			Value:      "different",
+		},
+		{
+			LocationID: 4,
+			TextTag:    "a2",
+			Value:      "a2",
+		},
+		{
+			LocationID: 4,
+			TextTag:    "b1",
+			Value:      "b1",
+		},
+	},
+	Location: []*model.Location{
+		nil,
+		{
+			LocationID:    1,
+			BookNumber:    sql.NullInt32{1, true},
+			ChapterNumber: sql.NullInt32{2, true},
+			KeySymbol:     sql.NullString{"nwtsty", true},
+			MepsLanguage:  2,
+			LocationType:  0,
+			Title:         sql.NullString{"1. Mose 2", true},
+		},
+		{
+			LocationID:   2,
+			KeySymbol:    sql.NullString{"nwtsty", true},
+			MepsLanguage: 2,
+			LocationType: 1,
+		},
+		{
+			LocationID:    3,
+			BookNumber:    sql.NullInt32{1, true},
+			ChapterNumber: sql.NullInt32{1, true},
+			KeySymbol:     sql.NullString{"nwtsty", true},
+			MepsLanguage:  2,
+			LocationType:  0,
+			Title:         sql.NullString{"1. Mose 1", true},
+		},
+		{
+			LocationID:   4,
+			DocumentID:   sql.NullInt32{1102021811, true},
+			KeySymbol:    sql.NullString{"lffi", true},
+			MepsLanguage: 2,
+			LocationType: 0,
+		},
+	},
+	Note: []*model.Note{
+		nil,
+		{
+			NoteID:          1,
+			GUID:            "DE4A2CDA-9892-4A94-AF4B-22EBE05A05CA",
+			UserMarkID:      sql.NullInt32{1, true},
+			LocationID:      sql.NullInt32{1, true},
+			Title:           sql.NullString{"So wurde die Erschaffung von Himmel und Erde und allem, was dazugehört, beendet.", true},
+			Content:         sql.NullString{"📝 on the right side", true},
+			LastModified:    "2020-09-15T13:47:56+00:00",
+			BlockType:       2,
+			BlockIdentifier: sql.NullInt32{1, true},
+		},
+		{
+			NoteID:       2,
+			GUID:         "E36B34A0-B70F-4590-9D69-5887AB65A6D5",
+			Title:        sql.NullString{"Same Note", true},
+			Content:      sql.NullString{"This note is also available on the other side. Though this one is newer 😏", true},
+			LastModified: "2020-09-20T13:52:25+00:00",
+			BlockType:    0,
+		},
+	},
+	Tag: []*model.Tag{
+		nil,
+		{
+			TagID:   1,
+			TagType: 0,
+			Name:    "Favorite",
+		},
+		{
+			TagID:   2,
+			TagType: 1,
+			Name:    "Right",
+		},
+		{
+			TagID:   3,
+			TagType: 1,
+			Name:    "Same",
+		},
+	},
+	TagMap: []*model.TagMap{
+		nil,
+		{
+			TagMapID: 1,
+			NoteID:   sql.NullInt32{1, true},
+			TagID:    2,
+			Position: 0,
+		},
+		{
+			TagMapID: 2,
+			NoteID:   sql.NullInt32{2, true},
+			TagID:    3,
+			// Should normally be 0, but changed it to 1 to detect
+			// if merger recognizes that its still the same entry,
+			// just with a different position
+			Position: 1,
+		},
+	},
+	UserMark: []*model.UserMark{
+		nil,
+		{
+			UserMarkID:   1,
+			ColorIndex:   1,
+			LocationID:   1,
+			StyleIndex:   0,
+			UserMarkGUID: "54C23825-AC1E-4890-8041-92B39C5E4B17",
+			Version:      1,
+		},
+		{
+			UserMarkID:   2,
+			ColorIndex:   1,
+			LocationID:   3,
+			StyleIndex:   0,
+			UserMarkGUID: "A098D2B0-7613-4676-9E96-442755105D9A",
+		},
+		{
+			UserMarkID:   3,
+			ColorIndex:   1,
+			LocationID:   3,
+			StyleIndex:   0,
+			UserMarkGUID: "A86DECC8-69B1-4A43-A3A1-F1CA7B8E8388",
+			Version:      1,
+		},
+		{
+			UserMarkID:   4,
+			ColorIndex:   2,
+			LocationID:   1,
+			StyleIndex:   0,
+			UserMarkGUID: "No BlockRanges",
+			Version:      1,
+		},
+	},
+}
+
+var mergedAllLeftDBEmptyBR = &model.Database{
+	BlockRange: []*model.BlockRange{
+		nil,
+		{
+			BlockRangeID: 1,
+			BlockType:    2,
+			Identifier:   1,
+			StartToken:   sql.NullInt32{0, true},
+			EndToken:     sql.NullInt32{7, true},
+			UserMarkID:   1,
+		},
+		{
+			BlockRangeID: 2,
+			BlockType:    2,
+			Identifier:   1,
+			StartToken:   sql.NullInt32{0, true},
+			EndToken:     sql.NullInt32{15, true},
+			UserMarkID:   2,
+		},
+		{
+			BlockRangeID: 3,
+			BlockType:    2,
+			Identifier:   2,
+			StartToken:   sql.NullInt32{13, true},
+			EndToken:     sql.NullInt32{26, true},
+			UserMarkID:   3,
+		},
+	},
+	Bookmark: []*model.Bookmark{
+		nil,
+		{
+			BookmarkID:            1,
+			LocationID:            1,
+			PublicationLocationID: 2,
+			Title:                 "1. Mose 1:1",
+			Snippet:               sql.NullString{"1 Am Anfang erschuf Gott Himmel und Erde.", true},
+			BlockType:             2,
+			BlockIdentifier:       sql.NullInt32{1, true},
+		},
+	},
+	InputField: []*model.InputField{
+		nil,
+		{
+			LocationID: 4,
+			TextTag:    "a1",
+			Value:      "a1",
+		},
+		{
+			LocationID: 4,
+			TextTag:    "a2",
+			Value:      "a2",
+		},
+		{
+			LocationID: 4,
+			TextTag:    "b1",
+			Value:      "b1",
+		},
+	},
+	Location: []*model.Location{
+		nil,
+		{
+			LocationID:    1,
+			BookNumber:    sql.NullInt32{1, true},
+			ChapterNumber: sql.NullInt32{1, true},
+			KeySymbol:     sql.NullString{"nwtsty", true},
+			MepsLanguage:  2,
+			LocationType:  0,
+			Title:         sql.NullString{"1. Mose 1", true},
+		},
+		{
+			LocationID:   2,
+			KeySymbol:    sql.NullString{"nwtsty", true},
+			MepsLanguage: 2,
+			LocationType: 1,
+		},
+		{
+			LocationID:    3,
+			BookNumber:    sql.NullInt32{1, true},
+			ChapterNumber: sql.NullInt32{2, true},
+			KeySymbol:     sql.NullString{"nwtsty", true},
+			MepsLanguage:  2,
+			LocationType:  0,
+			Title:         sql.NullString{"1. Mose 2", true},
+		},
+		{
+			LocationID:   4,
+			DocumentID:   sql.NullInt32{1102021811, true},
+			KeySymbol:    sql.NullString{"lffi", true},
+			MepsLanguage: 2,
+			LocationType: 0,
+		},
+	},
+	Note: []*model.Note{
+		nil,
+		{
+			NoteID:          1,
+			GUID:            "92B192B4-B0B9-49B2-949F-7A8BA6406AF4",
+			UserMarkID:      sql.NullInt32{1, true},
+			LocationID:      sql.NullInt32{1, true},
+			Title:           sql.NullString{"Am Anfang erschuf Gott Himmel und Erde.", true},
+			Content:         sql.NullString{"📝 for left version", true},
+			LastModified:    "2020-09-15T13:45:38+00:00",
+			BlockType:       2,
+			BlockIdentifier: sql.NullInt32{1, true},
+		},
+		{
+			NoteID:       2,
+			GUID:         "E36B34A0-B70F-4590-9D69-5887AB65A6D5",
+			Title:        sql.NullString{"Same Note", true},
+			Content:      sql.NullString{"This note is also available on the other side", true},
+			LastModified: "2020-09-15T13:52:25+00:00",
+			BlockType:    0,
+		},
+		{
+			NoteID:          3,
+			GUID:            "DE4A2CDA-9892-4A94-AF4B-22EBE05A05CA",
+			UserMarkID:      sql.NullInt32{1, true},
+			LocationID:      sql.NullInt32{1, true},
+			Title:           sql.NullString{"So wurde die Erschaffung von Himmel und Erde und allem, was dazugehört, beendet.", true},
+			Content:         sql.NullString{"📝 on the right side", true},
+			LastModified:    "2020-09-15T13:47:56+00:00",
+			BlockType:       2,
+			BlockIdentifier: sql.NullInt32{1, true},
+		},
+	},
+	Tag: []*model.Tag{
+		nil,
+		{
+			TagID:   1,
+			TagType: 0,
+			Name:    "Favorite",
+		},
+		{
+			TagID:   2,
+			TagType: 1,
+			Name:    "Left",
+		},
+		{
+			TagID:   3,
+			TagType: 1,
+			Name:    "Same",
+		},
+		{
+			TagID:   4,
+			TagType: 1,
+			Name:    "Right",
+		},
+	},
+	TagMap: []*model.TagMap{
+		nil,
+		{
+			TagMapID: 1,
+			NoteID:   sql.NullInt32{1, true},
+			TagID:    2,
+			Position: 0,
+		},
+		{
+			TagMapID: 2,
+			NoteID:   sql.NullInt32{2, true},
+			TagID:    3,
+			Position: 0,
+		},
+		{
+			TagMapID: 3,
+			NoteID:   sql.NullInt32{3, true},
+			TagID:    4,
+			Position: 0,
+		},
+	},
+	UserMark: []*model.UserMark{
+		nil,
+		{
+			UserMarkID:   1,
+			ColorIndex:   1,
+			LocationID:   1,
+			StyleIndex:   0,
+			UserMarkGUID: "0D5523D9-F784-4B08-A86D-D517F4EB17DE",
+			Version:      1,
+		},
+		{
+			UserMarkID:   2,
+			ColorIndex:   1,
+			LocationID:   3,
+			StyleIndex:   0,
+			UserMarkGUID: "54C23825-AC1E-4890-8041-92B39C5E4B17",
+			Version:      1,
+		},
+		{
+			UserMarkID:   3,
+			ColorIndex:   1,
+			LocationID:   1,
+			StyleIndex:   0,
+			UserMarkGUID: "A86DECC-69B1-4A43-A3A1-F1CA7B8E8388",
 			Version:      1,
 		},
 	},

--- a/merger/UserMarkBlockRangeMerger.go
+++ b/merger/UserMarkBlockRangeMerger.go
@@ -401,7 +401,8 @@ func ingestUMBR(left []*model.UserMarkBlockRange, right []*model.UserMarkBlockRa
 // joinToUserMarkBlockRange joins entries of UserMark and BlockRange together creating
 // a slice of UserMarkBlockRange for which the index corresponds to the UserMarkID.
 // It expects the IDs of UserMark and BlockRange to correspond to their
-// index within in um and br!
+// index within in um and br! If a UserMark doesn't have BlockRanges, it will
+// be removed from the result.
 func joinToUserMarkBlockRange(um []*model.UserMark, br []*model.BlockRange) []*model.UserMarkBlockRange {
 	result := make([]*model.UserMarkBlockRange, len(um))
 	for i, entry := range um {
@@ -416,6 +417,16 @@ func joinToUserMarkBlockRange(um []*model.UserMark, br []*model.BlockRange) []*m
 			continue
 		}
 		result[entry.UserMarkID].BlockRanges = append(result[entry.UserMarkID].BlockRanges, model.MakeModelCopy(entry).(*model.BlockRange))
+	}
+
+	// Remove UserMarks that don't have BlockRanges attached to them (e.g. "empty" markings)
+	for i, umbr := range result {
+		if umbr == nil {
+			continue
+		}
+		if len(umbr.BlockRanges) == 0 {
+			result[i] = nil
+		}
 	}
 
 	return result

--- a/merger/UserMarkBlockRangeMerger_test.go
+++ b/merger/UserMarkBlockRangeMerger_test.go
@@ -28,6 +28,11 @@ func TestMergeUserMarkAndBlockRange_without_conflict(t *testing.T) {
 			LocationID: 4,
 		},
 		{},
+		{
+			UserMarkID:   6,
+			LocationID:   1,
+			UserMarkGUID: "No BlockRange",
+		},
 	}
 	leftBR := []*model.BlockRange{
 		nil,
@@ -82,6 +87,11 @@ func TestMergeUserMarkAndBlockRange_without_conflict(t *testing.T) {
 		{
 			UserMarkID: 5,
 			LocationID: 30,
+		},
+		{
+			UserMarkID:   6,
+			LocationID:   1,
+			UserMarkGUID: "No BlockRange",
 		},
 	}
 	rightBR := []*model.BlockRange{
@@ -3009,12 +3019,7 @@ func Test_joinToUserMarkBlockRange(t *testing.T) {
 			},
 		},
 		nil,
-		{
-			UserMark: &model.UserMark{
-				UserMarkID: 4,
-			},
-			BlockRanges: []*model.BlockRange{},
-		},
+		nil,
 		nil,
 	}
 


### PR DESCRIPTION
The "duplicate" check for UserMarks is based on the collision check of the BlockRanges. So if no collision is detected for a duplicate marking, the duplicate itself will not be detected. This is an issue for UserMarks that don't have any associated BlockRanges: Duplicates won't be detected, which in the end results in a `UNIQUE constraint failed: UserMark.UserMarkGuid` error when exporting.
This adds a check for markings that don't have any BlockRanges attached to them. They will be removed now, as they aren't useful anyway.