### PR TITLE
🐛 Nil pointer on DBContainsPlaylists if DB not loaded

### DIFF
--- a/gomobile/Database.go
+++ b/gomobile/Database.go
@@ -78,6 +78,10 @@ func (dbw *DatabaseWrapper) DBIsLoaded(side string) bool {
 
 // DBContainsPlaylists indicates if a DB on the given side contains playlists.
 func (dbw *DatabaseWrapper) DBContainsPlaylists(side string) bool {
+	if !dbw.DBIsLoaded(side) {
+		return false
+	}
+
 	switch side {
 	case "leftSide":
 		return dbw.left.ContainsPlaylists

--- a/gomobile/Database_test.go
+++ b/gomobile/Database_test.go
@@ -246,6 +246,12 @@ func TestDatabaseWrapper_DBContainsPlaylists(t *testing.T) {
 			side: "wrong",
 			want: false,
 		},
+		{
+			name:      "DB not loaded",
+			dbWrapper: &DatabaseWrapper{},
+			side:      "rightSide",
+			want:      false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
The app would crash after a failed import and a check if the DB contained playlists. This is fixed now.