### PR TITLE
Support schema version range

### DIFF
--- a/model/manifest.go
+++ b/model/manifest.go
@@ -15,7 +15,8 @@ import (
 )
 
 const version = 1
-const schemaVersion = 14
+const supportedSchemaVersionMin = 13
+const supportedSchemaVersionMax = 14
 
 type manifest struct {
 	CreationDate   string         `json:"creationDate"`
@@ -61,13 +62,13 @@ func (mfst *manifest) validateManifest() error {
 			"You might need to upgrade to a newer version of JW Library first", version, mfst.Version)
 	}
 
-	if mfst.UserDataBackup.SchemaVersion > schemaVersion {
-		return fmt.Errorf("schema version is too new. Should be %d is %d. "+
-			"Make sure you use the latest version of the merger", schemaVersion, mfst.UserDataBackup.SchemaVersion)
+	if mfst.UserDataBackup.SchemaVersion > supportedSchemaVersionMax {
+		return fmt.Errorf("schema version is too new. Should be up to %d is %d. "+
+			"Make sure you use the latest version of the merger", supportedSchemaVersionMax, mfst.UserDataBackup.SchemaVersion)
 	}
-	if mfst.UserDataBackup.SchemaVersion < schemaVersion {
-		return fmt.Errorf("schema version is too old. Should be %d is %d. "+
-			"You might need to upgrade to a newer version of JW Library first", schemaVersion, mfst.UserDataBackup.SchemaVersion)
+	if mfst.UserDataBackup.SchemaVersion < supportedSchemaVersionMin {
+		return fmt.Errorf("schema version is too old. Should be at least %d is %d. "+
+			"You might need to upgrade to a newer version of JW Library first", supportedSchemaVersionMin, mfst.UserDataBackup.SchemaVersion)
 	}
 
 	return nil
@@ -94,7 +95,7 @@ func generateManifest(backupName string, dbFile string) (*manifest, error) {
 			LastModifiedDate: time.Now().Format("2006-01-02T15:04:05-07:00"),
 			Hash:             hash,
 			DatabaseName:     filepath.Base(dbFile),
-			SchemaVersion:    schemaVersion,
+			SchemaVersion:    supportedSchemaVersionMax,
 			DeviceName:       "go-jwlm",
 		},
 		Name:    backupName,

--- a/model/manifest_test.go
+++ b/model/manifest_test.go
@@ -69,7 +69,7 @@ func Test_manifest_validateManifest2(t *testing.T) {
 		wantErr assert.ErrorAssertionFunc
 	}{
 		{
-			name: "All good",
+			name: "Newest schema version",
 			mfst: &manifest{
 				UserDataBackup: userDataBackup{
 					SchemaVersion: 14,
@@ -77,6 +77,40 @@ func Test_manifest_validateManifest2(t *testing.T) {
 				Version: 1,
 			},
 			wantErr: assert.NoError,
+		},
+		{
+			name: "Older but supported schema version",
+			mfst: &manifest{
+				UserDataBackup: userDataBackup{
+					SchemaVersion: 13,
+				},
+				Version: 1,
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Schema version too old",
+			mfst: &manifest{
+				UserDataBackup: userDataBackup{
+					SchemaVersion: 12,
+				},
+				Version: 1,
+			},
+			wantErr: func(tt assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorContains(tt, err, "schema version is too old. Should be at least 13 is 12")
+			},
+		},
+		{
+			name: "Schema version too new",
+			mfst: &manifest{
+				UserDataBackup: userDataBackup{
+					SchemaVersion: 15,
+				},
+				Version: 1,
+			},
+			wantErr: func(tt assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorContains(tt, err, "schema version is too new. Should be up to 14 is 15")
+			},
 		},
 		{
 			name: "Manifest version too old",
@@ -100,30 +134,6 @@ func Test_manifest_validateManifest2(t *testing.T) {
 			},
 			wantErr: func(tt assert.TestingT, err error, i ...interface{}) bool {
 				return assert.ErrorContains(tt, err, "manifest version is too new. Should be 1 is 2")
-			},
-		},
-		{
-			name: "Schema version too old",
-			mfst: &manifest{
-				UserDataBackup: userDataBackup{
-					SchemaVersion: 13,
-				},
-				Version: 1,
-			},
-			wantErr: func(tt assert.TestingT, err error, i ...interface{}) bool {
-				return assert.ErrorContains(tt, err, "schema version is too old. Should be 14 is 13")
-			},
-		},
-		{
-			name: "Schema version too new",
-			mfst: &manifest{
-				UserDataBackup: userDataBackup{
-					SchemaVersion: 15,
-				},
-				Version: 1,
-			},
-			wantErr: func(tt assert.TestingT, err error, i ...interface{}) bool {
-				return assert.ErrorContains(tt, err, "schema version is too new. Should be 14 is 15")
 			},
 		},
 	}

--- a/model/testdata/manifest_outdated.json
+++ b/model/testdata/manifest_outdated.json
@@ -4,7 +4,7 @@
     "lastModifiedDate": "2020-04-09T05:47:26+02:00",
     "hash": "d87a67028133cc4de5536affe1b072841def95899b7f7450a5622112b4b5e63f",
     "databaseName": "user_data.db",
-    "schemaVersion": 13,
+    "schemaVersion": 12,
     "deviceName": "iPhone"
   },
   "name": "UserDataBackup_2020-04-11_iPhone",


### PR DESCRIPTION
For some reason, the latest JW Library version moved the schema version back to 13. In the hope that in a next version schema 14 still doesn't contain changes, we are now allowing a range of supported schema versions. This means a backup can be of version 13 AND 14 and still be considered compatible.