### PR TITLE
Added linux-arm64 as arch for goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,6 +18,15 @@ builds:
       - linux
     goarch:
       - amd64 
+  - id: linux-arm64
+    env:
+      - CGO_ENABLED=1
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=aarch64-linux-gnu-g++
+    goos:
+      - linux
+    goarch:
+      - arm64
   - id: windows-amd64
     env:
       - CGO_ENABLED=1


### PR DESCRIPTION
This PR adds a `linux-arm64` version. Required to run go-jwlm e.g. on a Raspberry Pi 5.

I've successfuly build a arm64 version with the GitHub Pipeline in this Repo in my Fork:
https://github.com/JoelKle/go-jwlm/releases/tag/0.5.7-beta

Works perfect :)
Thank you for your work!