### PR TITLE
Support custom temporary directory

### DIFF
--- a/cmd/compare_test.go
+++ b/cmd/compare_test.go
@@ -1,10 +1,9 @@
+//go:build !windows
 // +build !windows
 
 package cmd
 
 import (
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -17,9 +16,7 @@ import (
 func Test_compare(t *testing.T) {
 	t.Parallel()
 
-	tmp, err := ioutil.TempDir("", "go-jwlm")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	emptyFilename := filepath.Join(tmp, "empty.jwlibrary")
 	leftFilename := filepath.Join(tmp, "left.jwlibrary")

--- a/cmd/merge_test.go
+++ b/cmd/merge_test.go
@@ -6,8 +6,6 @@ package cmd
 import (
 	"bytes"
 	"database/sql"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -22,9 +20,7 @@ import (
 func Test_merge(t *testing.T) {
 	t.Parallel()
 
-	tmp, err := ioutil.TempDir("", "go-jwlm")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	emptyFilename := filepath.Join(tmp, "empty.jwlibrary")
 	leftFilename := filepath.Join(tmp, "left.jwlibrary")

--- a/cmd/purge_test.go
+++ b/cmd/purge_test.go
@@ -4,8 +4,6 @@
 package cmd
 
 import (
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -18,9 +16,7 @@ import (
 func Test_purge(t *testing.T) {
 	t.Parallel()
 
-	tmp, err := ioutil.TempDir("", "go-jwlm")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	inputFilename := filepath.Join(tmp, "left.jwlibrary")
 	assert.NoError(t, leftDB.ExportJWLBackup(inputFilename))

--- a/gomobile/CatalogDB_test.go
+++ b/gomobile/CatalogDB_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package gomobile
@@ -6,7 +7,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -20,15 +20,13 @@ import (
 )
 
 func TestDownloadCatalog(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "go-jwlm")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if strings.Contains(req.URL.String(), "manifest.json") {
 			rw.Write([]byte(`{"version": 1, "current": "164a1c4b-4dbd-4909-8f88-8e7a18c562f2"}`))
 		} else {
-			data, err := ioutil.ReadFile(filepath.Join("../publication/testdata", "catalog.db.gz"))
+			data, err := os.ReadFile(filepath.Join("../publication/testdata", "catalog.db.gz"))
 			assert.NoError(t, err)
 			rw.Write(data)
 		}
@@ -62,9 +60,7 @@ func TestDownloadCatalog(t *testing.T) {
 }
 
 func TestDownloadManager_CancelDownload(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "go-jwlm")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	dm := DownloadCatalog(filepath.Join(tmp, "catalog.db"))
 	dm.CancelDownload()
@@ -77,14 +73,13 @@ func TestDownloadManager_CancelDownload(t *testing.T) {
 }
 
 func TestCatalogNeedsUpdate(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "go-jwlm")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	assert.True(t, CatalogNeedsUpdate("not-valid-path"))
 
 	filePath := filepath.Join(tmp, "catalog.db")
-	_, err = os.Create(filePath)
+	_, err := os.Create(filePath)
+	assert.NoError(t, err)
 
 	assert.False(t, CatalogNeedsUpdate(filePath))
 
@@ -93,12 +88,11 @@ func TestCatalogNeedsUpdate(t *testing.T) {
 }
 
 func TestCatalogExists(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "go-jwlm")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	filePath := filepath.Join(tmp, "catalog.db")
-	_, err = os.Create(filePath)
+	_, err := os.Create(filePath)
+	assert.NoError(t, err)
 
 	assert.False(t, CatalogExists("not-valid-path"))
 	assert.True(t, CatalogExists(filePath))

--- a/gomobile/Database.go
+++ b/gomobile/Database.go
@@ -10,6 +10,8 @@ import (
 // DatabaseWrapper wraps the left, right, and merged
 // Database structs so they can be used with Gomobile.
 type DatabaseWrapper struct {
+	TempDir string
+
 	left   *model.Database
 	right  *model.Database
 	merged *model.Database
@@ -28,6 +30,7 @@ type DatabaseWrapper struct {
 // on the given side.
 func (dbw *DatabaseWrapper) ImportJWLBackup(filename string, side string) error {
 	db := &model.Database{
+		TempDir:       dbw.TempDir,
 		SkipPlaylists: dbw.skipPlaylists,
 	}
 
@@ -58,7 +61,9 @@ func (dbw *DatabaseWrapper) SkipPlaylists(skipPlaylists bool) {
 func (dbw *DatabaseWrapper) Init() {
 	dbw.leftTmp = model.MakeDatabaseCopy(dbw.left)
 	dbw.rightTmp = model.MakeDatabaseCopy(dbw.right)
-	dbw.merged = &model.Database{}
+	dbw.merged = &model.Database{
+		TempDir: dbw.TempDir,
+	}
 	merger.PrepareDatabasesPreMerge(dbw.leftTmp, dbw.rightTmp)
 }
 

--- a/gomobile/Database_test.go
+++ b/gomobile/Database_test.go
@@ -4,8 +4,6 @@
 package gomobile
 
 import (
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -181,9 +179,7 @@ func TestDatabaseWrapper_DBIsLoaded(t *testing.T) {
 }
 
 func TestDatabaseWrapper_ExportMerged(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "go-jwlm")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	dbw := &DatabaseWrapper{}
 	dbw.merged = &model.Database{}

--- a/gomobile/Merge_test.go
+++ b/gomobile/Merge_test.go
@@ -5,8 +5,6 @@ package gomobile
 
 import (
 	"database/sql"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -164,9 +162,7 @@ func Test_MergeNwt(t *testing.T) {
 func Test_MergeNwtDifferentDocID(t *testing.T) {
 	// As the cleanup happens in the PostMerge hook, which is called on export,
 	// we also need to export the merged DB
-	tmp, err := ioutil.TempDir("", "go-jwlm")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	dbw := DatabaseWrapper{
 		left:  model.MakeDatabaseCopy(leftDBNwtWithDifferentDocID),

--- a/model/Database.go
+++ b/model/Database.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -767,7 +766,7 @@ func insertEntries(sqlite *sql.DB, m []Model) error {
 
 // createEmptySQLiteDB creates a new SQLite database at filename with the base userData.db from JWLibrary
 func createEmptySQLiteDB(filename string) error {
-	if err := ioutil.WriteFile(filename, userDataDatabaseFile, 0644); err != nil {
+	if err := os.WriteFile(filename, userDataDatabaseFile, 0644); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("Error while saving new SQLite database at %s", filename))
 	}
 

--- a/model/Database_test.go
+++ b/model/Database_test.go
@@ -7,7 +7,6 @@ import (
 	_ "embed"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -864,13 +863,10 @@ func TestDatabase_ExportJWLBackup(t *testing.T) {
 
 func Test_createEmptySQLiteDB(t *testing.T) {
 	// Create tmp folder and place all files there
-	tmp, err := ioutil.TempDir("", "go-jwlm")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	path := filepath.Join(tmp, userDataFilename)
-	err = createEmptySQLiteDB(path)
-	assert.NoError(t, err)
+	assert.NoError(t, createEmptySQLiteDB(path))
 
 	// Test if file has correct hash
 	f, err := os.Open(path)
@@ -889,9 +885,7 @@ func Test_createEmptySQLiteDB(t *testing.T) {
 
 func TestDatabase_saveToNewSQLite(t *testing.T) {
 	// Create tmp folder and place all files there
-	tmp, err := ioutil.TempDir("", "go-jwlm")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	db := Database{
 		BlockRange: []*BlockRange{{3, 2, 13, sql.NullInt32{Int32: 0, Valid: true}, sql.NullInt32{Int32: 14, Valid: true}, 3}},

--- a/model/Database_test.go
+++ b/model/Database_test.go
@@ -203,12 +203,15 @@ func TestDatabase_PurgeTables(t *testing.T) {
 }
 
 func TestMakeDatabaseCopy(t *testing.T) {
-	db := &Database{}
+	db := &Database{
+		TempDir: "a-temp-dir",
+	}
 
 	path := filepath.Join("testdata", userDataFilename)
 	assert.NoError(t, db.importSQLite(path))
 
 	dbCp := MakeDatabaseCopy(db)
+	assert.Equal(t, db.TempDir, dbCp.TempDir)
 	assertEqualNotDeepSame(t, db.BlockRange, dbCp.BlockRange)
 	assertEqualNotDeepSame(t, db.Bookmark, dbCp.Bookmark)
 	assertEqualNotDeepSame(t, db.InputField, dbCp.InputField)

--- a/model/manifest.go
+++ b/model/manifest.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -41,7 +40,7 @@ func (mfst *manifest) importManifest(path string) error {
 	}
 	defer file.Close()
 
-	blob, _ := ioutil.ReadAll(file)
+	blob, _ := io.ReadAll(file)
 
 	err = json.Unmarshal([]byte(blob), &mfst)
 	if err != nil {
@@ -113,7 +112,7 @@ func (mfst *manifest) exportManifest(path string) error {
 		return errors.Wrap(err, "Error while marshalling manifest")
 	}
 
-	if err := ioutil.WriteFile(path, bytes, 0644); err != nil {
+	if err := os.WriteFile(path, bytes, 0644); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("Error while saving manifest file at %v", path))
 	}
 

--- a/model/manifest_test.go
+++ b/model/manifest_test.go
@@ -2,8 +2,6 @@ package model
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -158,13 +156,11 @@ func Test_generateManifest(t *testing.T) {
 }
 
 func Test_exportManifest(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "go-jwlm")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	path := filepath.Join(tmp, "test_manifest.json")
 	fmt.Println(path)
-	err = exampleManifest.exportManifest(path)
+	err := exampleManifest.exportManifest(path)
 	assert.NoError(t, err)
 	assert.FileExists(t, path)
 

--- a/publication/CatalogDB.go
+++ b/publication/CatalogDB.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"time"
@@ -75,7 +75,7 @@ func DownloadCatalog(ctx context.Context, prgrs chan Progress, dst string) error
 	}
 
 	// Create tmp folder and place all files there
-	tmp, err := ioutil.TempDir("", "go-jwlm")
+	tmp, err := os.MkdirTemp("", "go-jwlm")
 	if err != nil {
 		return errors.Wrap(err, "Error while creating temporary directory")
 	}
@@ -133,7 +133,7 @@ Loop:
 	}
 
 	// Extract and save at dst
-	data, err := ioutil.ReadFile(resp.Filename)
+	data, err := os.ReadFile(resp.Filename)
 	if err != nil {
 		return errors.Wrap(err, "Error while reading catalog.db.gz")
 	}
@@ -167,7 +167,7 @@ func fetchManifest(ctx context.Context) (catalogManifest, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return catalogManifest{}, errors.Wrap(err, "Error while reading response body for catalog manifest")
 	}


### PR DESCRIPTION
Users on iOS reported issues when importing backups:

> Error while creating temporary directory: mkdir /var/folders/t_/0w12llq155s3bcljc16_hj_c0000gn/T/go-jwlm1513177742: operation not permitted

It looks like Go might now always be able to determine the correct path for temporary directories.

With this PR we now support customizing the tempDir. This will be used in the iOS app to create a tempDir via Swift and then provide it to go-jwlm.

## Other changes

### Remove ioutil

The package has been deprecated.