### PR TITLE
Rename go-jwlm to go-library-merger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,9 @@ jobs:
                     -e CGO_ENABLED=1 
                     --rm 
                     --privileged
-                    -v $GITHUB_WORKSPACE:/go/src/github.com/AndreasSko/go-jwlm 
+                    -v $GITHUB_WORKSPACE:/go/src/github.com/AndreasSko/go-library-merger 
                     -v /var/run/docker.sock:/var/run/docker.sock 
-                    -w /go/src/github.com/AndreasSko/go-jwlm 
+                    -w /go/src/github.com/AndreasSko/go-library-merger 
                     goreleaser/goreleaser-cross:v1.20 
                     --skip-publish
                     --skip-validate
@@ -33,8 +33,8 @@ jobs:
                     -e CGO_ENABLED=1 
                     --rm 
                     --privileged
-                    -v $GITHUB_WORKSPACE:/go/src/github.com/AndreasSko/go-jwlm 
+                    -v $GITHUB_WORKSPACE:/go/src/github.com/AndreasSko/go-library-merger 
                     -v /var/run/docker.sock:/var/run/docker.sock 
-                    -w /go/src/github.com/AndreasSko/go-jwlm 
+                    -w /go/src/github.com/AndreasSko/go-library-merger 
                     goreleaser/goreleaser-cross:v1.20 
         if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.prof
-go-jwlm
+library-merger
 *.pdf
 *.DS_Store
 2020-08-06.jwlibrary

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,8 +48,8 @@ changelog:
       - '^docs:'
       - '^test:'
 brews:
-  - name: go-jwlm
+  - name: library-merger
     repository:
       owner: andreassko
-      name: homebrew-go-jwlm
-    homepage: https://github.com/AndreasSko/go-jwlm
+      name: homebrew-go-library-merger
+    homepage: https://github.com/AndreasSko/go-library-merger

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Status](https://coveralls.io/repos/github/AndreasSko/go-library-merger/badge.svg?branch=master)](https://coveralls.io/github/AndreasSko/go-library-merger?branch=master)
 
 # library-merger
-A command-line tool to easily merge JW Library backups, written in Go.
+A command-line tool to easily merge JW Library® backups, written in Go.
 For the iOS version, visit [ios-jwlm](https://github.com/AndreasSko/ios-jwlm).
 
 library-merger allows you to merge two .jwlibrary backup files, while giving you
@@ -21,7 +21,7 @@ and press enter. The tool will merge all entries for you. If it encounters a
 conflict (like the same note with different content or two markings that
 overlap), it will ask you for directions: should it choose the left version or
 the right one? After that is finished, you have a nicely merged backup that you
-can import into your JW Library App. The first merge process might take some
+can import into your JW Library® App. The first merge process might take some
 time because of the number of possible conflicts, depending on how far apart you
 backups are. But if you merge them regularly, it should be a matter of seconds
 :) 
@@ -76,7 +76,7 @@ See the instructions on how to install Homebrew at https://brew.sh
 
 ## Mobile version
 If you want to merge backups using your iPhone or iPad, have a look at
-[JWLM](https://github.com/AndreasSko/ios-jwlm). It uses the whole merge
+[Library Merger](https://github.com/AndreasSko/ios-jwlm). It uses the whole merge
 logic of library-merger, but wraps it in a nice and easy to use iOS app. It is 
 already available on the [App Store](https://apps.apple.com/us/app/jwlm-jw-library-merger/id1539780103).
 
@@ -104,3 +104,14 @@ issue.
 Something is unclear, you have suggestions for documentation or you found a bug?
 Feel free to open an issue. I‘m happy to help, though please be patient if it
 takes a while for me to respond :)
+
+## Legal Notice
+
+This application is not owned or operated by
+Watch Tower Bible and Tract Society of Pennsylvania, however it is distributed
+with permission under a license from Watch Tower. All ownership rights to the
+content within the JW Library® application remain exclusively with Watch Tower
+Bible and Tract Society of Pennsylvania.
+
+JW Library® is a registered trademark owned exclusively by Watch Tower Bible
+and Tract Society of Pennsylvania ("Watch Tower").

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 [![Coverage
-Status](https://coveralls.io/repos/github/AndreasSko/go-jwlm/badge.svg?branch=master)](https://coveralls.io/github/AndreasSko/go-jwlm?branch=master)
+Status](https://coveralls.io/repos/github/AndreasSko/go-library-merger/badge.svg?branch=master)](https://coveralls.io/github/AndreasSko/go-library-merger?branch=master)
 
-# go-jwlm
+# library-merger
 A command-line tool to easily merge JW Library backups, written in Go.
 For the iOS version, visit [ios-jwlm](https://github.com/AndreasSko/ios-jwlm).
 
-go-jwlm allows you to merge two .jwlibrary backup files, while giving you
+library-merger allows you to merge two .jwlibrary backup files, while giving you
 control of the process - your notes are precious, and you shouldn‘t need to
 trust a program solving possible merge conflicts for you.
 
 I created this project with the goal of having a tool that is able to work on
 multiple operating systems, and even allowing it to be incorporated in other
-programs as a library (like an [iOS app](https://github.com/AndreasSko/ios-jwlm)). 
+programs as a library (like an [iOS app](https://github.com/AndreasSko/ios-jwlm)).
 It is - and will be for
 quite some time - a work-in-progress project, so I‘m always open for suggestion
 and especially reports if you encounter an unexpected behavior or other bugs. 
@@ -28,7 +28,7 @@ backups are. But if you merge them regularly, it should be a matter of seconds
 
 ## Usage
 ```shell
-go-jwlm merge <left-backup> <right-backup> <merged-backup>
+library-merger merge <left-backup> <right-backup> <merged-backup>
 ```
 
 If a conflict occurs while merging, the tool will ask for directions: should it
@@ -48,7 +48,7 @@ You can enable these solvers with the `--bookmarks`, `--markings`,
 `--notes`, and `--inputFields` flags:
 
 ```shell
-go-jwlm merge <left-backup> <right-backup> <merged-backup> --bookmarks chooseLeft --markings chooseRight --notes chooseNewest --inputFields chooseLeft
+library-merger merge <left-backup> <right-backup> <merged-backup> --bookmarks chooseLeft --markings chooseRight --notes chooseNewest --inputFields chooseLeft
 ```
 
 The conflict resolvers are helpful for regular merging when you are 
@@ -58,18 +58,18 @@ accidentally overwriting entries.
 
 ### Compare two backups
 To quickly compare two backup files and check if their content is equal,
-you can use the `go-jwlm compare <left-backup> <right-backup>` command. 
+you can use the `library-merger compare <left-backup> <right-backup>` command. 
 This one is mainly used for validation, but might be helpful in other 
 situations :)
 
 ## Installation 
 You can find the compiled binaries for Windows, Linux, and Mac under the
-[Release](https://github.com/AndreasSko/go-jwlm/releases) section. 
+[Release](https://github.com/AndreasSko/go-library-merger/releases) section. 
 
 ### Installation using Homebrew (Mac and Linux)
-go-jwlm can be easily installed using Hombrew:
+library-merger can be easily installed using Homebrew:
 ```shell
-brew install andreassko/homebrew-go-jwlm/go-jwlm
+brew install andreassko/homebrew-go-library-merger/library-merger
 ```
 
 See the instructions on how to install Homebrew at https://brew.sh
@@ -77,7 +77,7 @@ See the instructions on how to install Homebrew at https://brew.sh
 ## Mobile version
 If you want to merge backups using your iPhone or iPad, have a look at
 [JWLM](https://github.com/AndreasSko/ios-jwlm). It uses the whole merge
-logic of go-jwlm, but wraps it in a nice and easy to use iOS app. It is 
+logic of library-merger, but wraps it in a nice and easy to use iOS app. It is 
 already available on the [App Store](https://apps.apple.com/us/app/jwlm-jw-library-merger/id1539780103).
 
 There might come an Android version at some point, but as I personally
@@ -95,7 +95,7 @@ of this repo and run `gomobile bind -target <ios or android>`.
 
 ## A word of caution 
 It took me a while to trust my own program, but I still keep backups of my
-libraries - and so should you. Go-jwlm is still in beta-phase, so there is a
+libraries - and so should you. Library-merger is still in beta-phase, so there is a
 possibility that something might get lost because of a yet-to-find bug. So
 please keep that in mind and - again - if you found a bug, feel free to open an
 issue. 

--- a/cmd/compare.go
+++ b/cmd/compare.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/AlecAivazis/survey/v2/terminal"
-	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/AndreasSko/go-library-merger/model"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -13,7 +13,7 @@ import (
 var compareCmd = &cobra.Command{
 	Use:     "compare <left-backup> <right-backup>",
 	Short:   "Compare two JW Library backup files to see if they are equal",
-	Example: `go-jwlm compare left.jwlibrary right.jwlibrary`,
+	Example: `library-merger compare left.jwlibrary right.jwlibrary`,
 	Run: func(cmd *cobra.Command, args []string) {
 		leftFilename := args[0]
 		rightFilename := args[1]

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/terminal"
-	"github.com/AndreasSko/go-jwlm/merger"
-	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/AndreasSko/go-library-merger/merger"
+	"github.com/AndreasSko/go-library-merger/model"
 	"github.com/buger/goterm"
 	"github.com/jedib0t/go-pretty/table"
 	"github.com/spf13/cobra"
@@ -26,8 +26,8 @@ the right backup is detected, the user is asked to choose which side should
 be included in the merged backup. You are able to let the merger 
 automatically solve conflicts using the 'chooseLeft', 'chooseRight', and 
 'chooseNewest' resolvers (see Flags).`,
-	Example: `go-jwlm merge left.jwlibrary right.jwlibrary merged.jwlibrary
-go-jwlm merge left.jwlibrary right.jwlibrary merged.jwlibrary --bookmarks chooseLeft --markings chooseRight --notes chooseNewest --inputFields chooseRight`,
+	Example: `library-merger merge left.jwlibrary right.jwlibrary merged.jwlibrary
+library-merger merge left.jwlibrary right.jwlibrary merged.jwlibrary --bookmarks chooseLeft --markings chooseRight --notes chooseNewest --inputFields chooseRight`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		leftFilename := args[0]
 		rightFilename := args[1]

--- a/cmd/merge_test.go
+++ b/cmd/merge_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/AlecAivazis/survey/v2/terminal"
-	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/AndreasSko/go-library-merger/model"
 	expect "github.com/Netflix/go-expect"
 	"github.com/hinshun/vt10x"
 	"github.com/stretchr/testify/assert"

--- a/cmd/purge.go
+++ b/cmd/purge.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2/terminal"
-	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/AndreasSko/go-library-merger/model"
 	"github.com/MakeNowJust/heredoc"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -27,7 +27,7 @@ var purgeCmd = &cobra.Command{
 	 * Tag
 	 * TagMap
 	 * UserMark`),
-	Example: `go-jwlm purge original.jwlibrary purged.jwlibrary --tables=Note,Tag,TagMap`,
+	Example: `library-merger purge original.jwlibrary purged.jwlibrary --tables=Note,Tag,TagMap`,
 	Run: func(cmd *cobra.Command, args []string) {
 		inputFilename := args[0]
 		outputFilename := args[1]

--- a/cmd/purge_test.go
+++ b/cmd/purge_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/AlecAivazis/survey/v2/terminal"
-	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/AndreasSko/go-library-merger/model"
 	expect "github.com/Netflix/go-expect"
 	"github.com/stretchr/testify/assert"
 )

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,7 +14,7 @@ var cfgFile string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "go-jwlm",
+	Use:   "library-merger",
 	Short: "A utility to merge multiple JW Library backup files",
 }
 
@@ -34,7 +34,7 @@ func init() {
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 
-	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.go-jwlm.yaml)")
+	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.library-merger.yaml)")
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -50,9 +50,9 @@ func initConfig() {
 			os.Exit(1)
 		}
 
-		// Search config in home directory with name ".go-jwlm" (without extension).
+		// Search config in home directory with name ".library-merger" (without extension).
 		viper.AddConfigPath(home)
-		viper.SetConfigName(".go-jwlm")
+		viper.SetConfigName(".library-merger")
 	}
 
 	viper.AutomaticEnv() // read in environment variables that match

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/AndreasSko/go-jwlm
+module github.com/AndreasSko/go-library-merger
 
 go 1.24
 

--- a/gomobile/CatalogDB.go
+++ b/gomobile/CatalogDB.go
@@ -3,7 +3,7 @@ package gomobile
 import (
 	"context"
 
-	"github.com/AndreasSko/go-jwlm/publication"
+	"github.com/AndreasSko/go-library-merger/publication"
 )
 
 // DownloadManager keeps all the information of a running download, enabling it

--- a/gomobile/CatalogDB_test.go
+++ b/gomobile/CatalogDB_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/AndreasSko/go-jwlm/publication"
+	"github.com/AndreasSko/go-library-merger/publication"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/gomobile/Database.go
+++ b/gomobile/Database.go
@@ -3,8 +3,8 @@ package gomobile
 import (
 	"errors"
 
-	"github.com/AndreasSko/go-jwlm/merger"
-	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/AndreasSko/go-library-merger/merger"
+	"github.com/AndreasSko/go-library-merger/model"
 )
 
 // DatabaseWrapper wraps the left, right, and merged

--- a/gomobile/Database_test.go
+++ b/gomobile/Database_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/AndreasSko/go-library-merger/model"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/gomobile/Merge.go
+++ b/gomobile/Merge.go
@@ -1,7 +1,7 @@
 package gomobile
 
 import (
-	"github.com/AndreasSko/go-jwlm/merger"
+	"github.com/AndreasSko/go-library-merger/merger"
 	"github.com/pkg/errors"
 	_ "golang.org/x/mobile/bind"
 )

--- a/gomobile/MergeConflict.go
+++ b/gomobile/MergeConflict.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/AndreasSko/go-jwlm/merger"
-	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/AndreasSko/go-library-merger/merger"
+	"github.com/AndreasSko/go-library-merger/model"
 )
 
 // MergeConflictError indicates that a conflict happened while merging. It

--- a/gomobile/MergeConflict_test.go
+++ b/gomobile/MergeConflict_test.go
@@ -7,8 +7,8 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/AndreasSko/go-jwlm/merger"
-	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/AndreasSko/go-library-merger/merger"
+	"github.com/AndreasSko/go-library-merger/model"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/gomobile/Merge_test.go
+++ b/gomobile/Merge_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/AndreasSko/go-library-merger/model"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/gomobile/Publication.go
+++ b/gomobile/Publication.go
@@ -3,7 +3,7 @@ package gomobile
 import (
 	"encoding/json"
 
-	"github.com/AndreasSko/go-jwlm/publication"
+	"github.com/AndreasSko/go-library-merger/publication"
 )
 
 // PublicationLookup represents a lookup for a publication.

--- a/gomobile/Stats.go
+++ b/gomobile/Stats.go
@@ -3,7 +3,7 @@ package gomobile
 import (
 	"reflect"
 
-	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/AndreasSko/go-library-merger/model"
 )
 
 // DatabaseStats represents the rough number of entries

--- a/gomobile/Stats_test.go
+++ b/gomobile/Stats_test.go
@@ -5,7 +5,7 @@ package gomobile
 import (
 	"testing"
 
-	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/AndreasSko/go-library-merger/model"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/AndreasSko/go-jwlm/cmd"
+import "github.com/AndreasSko/go-library-merger/cmd"
 
 func main() {
 	cmd.Execute()

--- a/merger/BookmarkMerger.go
+++ b/merger/BookmarkMerger.go
@@ -1,7 +1,7 @@
 package merger
 
 import (
-	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/AndreasSko/go-library-merger/model"
 )
 
 // MergeBookmarks tries to merge the left and right slices of Bookmarks. If there is a

--- a/merger/BookmarkMerger_test.go
+++ b/merger/BookmarkMerger_test.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/AndreasSko/go-library-merger/model"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/merger/IDChanges.go
+++ b/merger/IDChanges.go
@@ -1,7 +1,7 @@
 package merger
 
 import (
-	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/AndreasSko/go-library-merger/model"
 )
 
 // IDChanges represents the changed ids of two slices of a model type

--- a/merger/IDChanges_test.go
+++ b/merger/IDChanges_test.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/AndreasSko/go-library-merger/model"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/merger/InputFieldMerger.go
+++ b/merger/InputFieldMerger.go
@@ -1,6 +1,6 @@
 package merger
 
-import "github.com/AndreasSko/go-jwlm/model"
+import "github.com/AndreasSko/go-library-merger/model"
 
 // MergeInputFields tries to merge the left and right slice of InputField. If there is a
 // collision, it returns an error asking for specification how it should handle it.

--- a/merger/InputFieldMerger_test.go
+++ b/merger/InputFieldMerger_test.go
@@ -3,7 +3,7 @@ package merger
 import (
 	"testing"
 
-	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/AndreasSko/go-library-merger/model"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/merger/LocationMerger.go
+++ b/merger/LocationMerger.go
@@ -3,7 +3,7 @@ package merger
 import (
 	"fmt"
 
-	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/AndreasSko/go-library-merger/model"
 )
 
 // MergeLocations merges two slices of Location into one and returns

--- a/merger/LocationMerger_test.go
+++ b/merger/LocationMerger_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/AndreasSko/go-library-merger/model"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/merger/MergeConflictSolver_test.go
+++ b/merger/MergeConflictSolver_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/AndreasSko/go-library-merger/model"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -226,19 +226,19 @@ func Test_parseResolver(t *testing.T) {
 	resolver, err = parseResolver("chooseLeft")
 	assert.NoError(t, err)
 	assert.Equal(t,
-		"github.com/AndreasSko/go-jwlm/merger.SolveConflictByChoosingLeft",
+		"github.com/AndreasSko/go-library-merger/merger.SolveConflictByChoosingLeft",
 		runtime.FuncForPC(reflect.ValueOf(resolver).Pointer()).Name())
 
 	resolver, err = parseResolver("chooseRight")
 	assert.NoError(t, err)
 	assert.Equal(t,
-		"github.com/AndreasSko/go-jwlm/merger.SolveConflictByChoosingRight",
+		"github.com/AndreasSko/go-library-merger/merger.SolveConflictByChoosingRight",
 		runtime.FuncForPC(reflect.ValueOf(resolver).Pointer()).Name())
 
 	resolver, err = parseResolver("chooseNewest")
 	assert.NoError(t, err)
 	assert.Equal(t,
-		"github.com/AndreasSko/go-jwlm/merger.SolveConflictByChoosingNewest",
+		"github.com/AndreasSko/go-library-merger/merger.SolveConflictByChoosingNewest",
 		runtime.FuncForPC(reflect.ValueOf(resolver).Pointer()).Name())
 
 	resolver, err = parseResolver("nonexistent")

--- a/merger/Merger.go
+++ b/merger/Merger.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"sort"
 
-	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/AndreasSko/go-library-merger/model"
 )
 
 // MergeSolution indicates wheter a entry came from the left or right

--- a/merger/Merger_test.go
+++ b/merger/Merger_test.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/AndreasSko/go-library-merger/model"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/merger/NoteMerger.go
+++ b/merger/NoteMerger.go
@@ -1,6 +1,6 @@
 package merger
 
-import "github.com/AndreasSko/go-jwlm/model"
+import "github.com/AndreasSko/go-library-merger/model"
 
 // MergeNotes tries to merge the left and right slice of Note. If there is a
 // collision, it returns an error asking for specification how it should handle it.

--- a/merger/NoteMerger_test.go
+++ b/merger/NoteMerger_test.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/AndreasSko/go-library-merger/model"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/merger/PrepareDatabase.go
+++ b/merger/PrepareDatabase.go
@@ -3,7 +3,7 @@ package merger
 import (
 	"fmt"
 
-	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/AndreasSko/go-library-merger/model"
 )
 
 // PrepareDatabasesPreMerge bundles function calls that are necessary for preparing the

--- a/merger/PrepareDatabase_test.go
+++ b/merger/PrepareDatabase_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/AndreasSko/go-library-merger/model"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/merger/TagMapMerger.go
+++ b/merger/TagMapMerger.go
@@ -3,7 +3,7 @@ package merger
 import (
 	"sort"
 
-	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/AndreasSko/go-library-merger/model"
 )
 
 // MergeTagMaps merges a left and right slice of TagMap. It automatically

--- a/merger/TagMapMerger_test.go
+++ b/merger/TagMapMerger_test.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/AndreasSko/go-library-merger/model"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/merger/TagMerger.go
+++ b/merger/TagMerger.go
@@ -1,6 +1,6 @@
 package merger
 
-import "github.com/AndreasSko/go-jwlm/model"
+import "github.com/AndreasSko/go-library-merger/model"
 
 // MergeTags tries to merge the left and right slice of Tag. If there is a
 // collision, it returns an error asking for specification how it should handle it.

--- a/merger/TagMerger_test.go
+++ b/merger/TagMerger_test.go
@@ -3,7 +3,7 @@ package merger
 import (
 	"testing"
 
-	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/AndreasSko/go-library-merger/model"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/merger/UserMarkBlockRangeMerger.go
+++ b/merger/UserMarkBlockRangeMerger.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/AndreasSko/go-library-merger/model"
 )
 
 // brFrom indicates from which mergeSide a *BlockRange

--- a/merger/UserMarkBlockRangeMerger_test.go
+++ b/merger/UserMarkBlockRangeMerger_test.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/AndreasSko/go-jwlm/model"
+	"github.com/AndreasSko/go-library-merger/model"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/model/Database.go
+++ b/model/Database.go
@@ -29,9 +29,11 @@ var userDataDatabaseFile []byte
 //go:embed data/default_thumbnail.png
 var defaultThumbnailFile []byte
 
-const manifestFilename = "manifest.json"
-const userDataFilename = "userData.db"
-const defaultThumbnailFilename = "default_thumbnail.png"
+const (
+	manifestFilename         = "manifest.json"
+	userDataFilename         = "userData.db"
+	defaultThumbnailFilename = "default_thumbnail.png"
+)
 
 // Database represents the JW Library database as a struct
 type Database struct {
@@ -240,7 +242,7 @@ func (db *Database) Equals(other *Database) bool {
 // included SQLite DB to the Database struct
 func (db *Database) ImportJWLBackup(filename string) error {
 	// Create tmp folder and place all files there
-	tmp, err := os.MkdirTemp(db.TempDir, "go-jwlm")
+	tmp, err := os.MkdirTemp(db.TempDir, "library-merger")
 	if err != nil {
 		return errors.Wrap(err, "Error while creating temporary directory")
 	}
@@ -600,7 +602,7 @@ func getSliceCapacity(sqlite *sql.DB, modelType Model) (int, error) {
 // ExportJWLBackup creates a .jwlibrary backup file out of a Database{} struct
 func (db *Database) ExportJWLBackup(filename string) error {
 	// Create tmp folder and place all files there
-	tmp, err := os.MkdirTemp(db.TempDir, "go-jwlm")
+	tmp, err := os.MkdirTemp(db.TempDir, "library-merger")
 	if err != nil {
 		return errors.Wrap(err, "Error while creating temporary directory")
 	}
@@ -614,7 +616,7 @@ func (db *Database) ExportJWLBackup(filename string) error {
 
 	// Create manifest.json
 	manifestPath := filepath.Join(tmp, manifestFilename)
-	mfst, err := generateManifest("go-jwlm", dbPath)
+	mfst, err := generateManifest("library-merger", dbPath)
 	if err != nil {
 		return errors.Wrap(err, "Error while generating manifest")
 	}
@@ -623,7 +625,7 @@ func (db *Database) ExportJWLBackup(filename string) error {
 	}
 
 	defaultThumbnailPath := filepath.Join(tmp, defaultThumbnailFilename)
-	if err := os.WriteFile(defaultThumbnailPath, defaultThumbnailFile, 0644); err != nil {
+	if err := os.WriteFile(defaultThumbnailPath, defaultThumbnailFile, 0o644); err != nil {
 		return fmt.Errorf("writing default thumbnail to %s: %w", defaultThumbnailPath, err)
 	}
 
@@ -766,7 +768,7 @@ func insertEntries(sqlite *sql.DB, m []Model) error {
 
 // createEmptySQLiteDB creates a new SQLite database at filename with the base userData.db from JWLibrary
 func createEmptySQLiteDB(filename string) error {
-	if err := os.WriteFile(filename, userDataDatabaseFile, 0644); err != nil {
+	if err := os.WriteFile(filename, userDataDatabaseFile, 0o644); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("Error while saving new SQLite database at %s", filename))
 	}
 

--- a/model/manifest.go
+++ b/model/manifest.go
@@ -13,9 +13,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-const version = 1
-const supportedSchemaVersionMin = 13
-const supportedSchemaVersionMax = 14
+const (
+	version                   = 1
+	supportedSchemaVersionMin = 13
+	supportedSchemaVersionMax = 14
+)
 
 type manifest struct {
 	CreationDate   string         `json:"creationDate"`
@@ -95,7 +97,7 @@ func generateManifest(backupName string, dbFile string) (*manifest, error) {
 			Hash:             hash,
 			DatabaseName:     filepath.Base(dbFile),
 			SchemaVersion:    supportedSchemaVersionMax,
-			DeviceName:       "go-jwlm",
+			DeviceName:       "library-merger",
 		},
 		Name:    backupName,
 		Type:    0,
@@ -112,7 +114,7 @@ func (mfst *manifest) exportManifest(path string) error {
 		return errors.Wrap(err, "Error while marshalling manifest")
 	}
 
-	if err := os.WriteFile(path, bytes, 0644); err != nil {
+	if err := os.WriteFile(path, bytes, 0o644); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("Error while saving manifest file at %v", path))
 	}
 

--- a/model/manifest_test.go
+++ b/model/manifest_test.go
@@ -16,7 +16,7 @@ var exampleManifest = &manifest{
 		Hash:             "e2e09ceba668bb1ad093b2db317237451a01ae9ff435b38c840b70dc434f184f",
 		DatabaseName:     userDataFilename,
 		SchemaVersion:    14,
-		DeviceName:       "go-jwlm",
+		DeviceName:       "library-merger",
 	},
 	Name:    "test",
 	Type:    0,
@@ -168,5 +168,4 @@ func Test_exportManifest(t *testing.T) {
 	err = otherMfst.importManifest(path)
 	assert.NoError(t, err)
 	assert.Equal(t, exampleManifest, otherMfst)
-
 }

--- a/publication/CatalogDB.go
+++ b/publication/CatalogDB.go
@@ -75,7 +75,7 @@ func DownloadCatalog(ctx context.Context, prgrs chan Progress, dst string) error
 	}
 
 	// Create tmp folder and place all files there
-	tmp, err := os.MkdirTemp("", "go-jwlm")
+	tmp, err := os.MkdirTemp("", "library-merger")
 	if err != nil {
 		return errors.Wrap(err, "Error while creating temporary directory")
 	}


### PR DESCRIPTION
`JW` is a trademark, which we can't use. With this PR we are renaming the project and all files that
refer to the old name to the new name `library-merger`. This name is already used for the iOS App, so it
makes sense to use it for the Go parts as well.